### PR TITLE
fix(docs): correct embed widget sandbox payments link

### DIFF
--- a/apps/docs/content/docs/build/embed-widget.mdx
+++ b/apps/docs/content/docs/build/embed-widget.mdx
@@ -169,7 +169,7 @@ loadLomiCheckout({
 });
 ```
 
-See [Sandbox payments](/start/first-payment) for test payment methods.
+See [Sandbox payments](/start/sandbox-payments) for test payment methods.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Fixes the embed widget guide cross-link to point at `/start/sandbox-payments` instead of `/start/first-payment` for test card and mobile money numbers.
- Docs content recovery (overview, sandbox, checkout, webhooks, platform guides) was already merged in `2628d6400`; this PR closes the last hygiene item from the recovery closure plan.

## Test plan

- [ ] Open `/build/embed-widget` and confirm the sandbox link resolves to the sandbox payments guide
- [ ] No other doc changes in this PR


Made with [Cursor](https://cursor.com)