### PR TITLE
docs: fix broken GitHub links on e-commerce extension pages

### DIFF
--- a/apps/docs/content/docs/build/ecommerce-extensions/index.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/index.fr.mdx
@@ -13,7 +13,7 @@ import { Callout } from '@/components/docs/docs-callout';
 
 Installez lomi. sur votre boutique sans recoder le tunnel de paiement. Ces modules créent des **sessions de paiement hébergées**, envoient le client vers la **page lomi. Checkout**, puis confirment le paiement via les **URL de retour** et les **webhooks marchands**.
 
-## Contrat technique partagé
+<h2 id="shared-technical-contract">Contrat technique partagé</h2>
 
 WooCommerce, Magento 2 et PrestaShop n’utilent que l’**API REST publique** lomi. (`/v1/checkout-sessions`). Ils **n’appellent pas** les RPC Supabase ni les endpoints internes Nest.
 
@@ -28,8 +28,8 @@ WooCommerce, Magento 2 et PrestaShop n’utilent que l’**API REST publique** 
 
 Formulation canonique à côté du code :
 
-- [Contrat d’intégration des plugins](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_CONTRACT.md)
-- [Liste de contrôle QA d’intégration](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_QA_CHECKLIST.md)
+- [Contrat technique partagé](#shared-technical-contract) (cette page)
+- [Vérifier les paiements](/build/guides/verify-payments) et [Traiter les webhooks](/build/advanced-guides/handling-webhooks)
 
 Avant la mise en production : [Intégration API](/start/first-payment), [Authentification](/api/authentication) et [Webhooks](/build/webhooks).
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/index.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/index.mdx
@@ -13,7 +13,7 @@ import { Callout } from '@/components/docs/docs-callout';
 
 Install lomi. on your store without writing checkout plumbing yourself. These modules create **hosted checkout sessions**, redirect shoppers to lomi. Checkout, then confirm payment via **return URLs** and **merchant webhooks**.
 
-## Shared technical contract
+<h2 id="shared-technical-contract">Shared technical contract</h2>
 
 WooCommerce, Magento 2, and PrestaShop talk only to lomi.’s **public REST API** (`/v1/checkout-sessions`). They do **not** call Supabase RPC or internal-only Nest endpoints.
 
@@ -26,10 +26,10 @@ WooCommerce, Magento 2, and PrestaShop talk only to lomi.’s **public REST API*
 | Paid state | Session `status` **`completed`**, with amount/currency checked against the cart/order |
 | Webhooks | `X-Lomi-Event` (e.g. `PAYMENT_SUCCEEDED`), `X-Lomi-Signature`, **HMAC-SHA256 hex** over the **raw** JSON body |
 
-For the canonical wording maintained next to source code, see the repo docs:
+For the canonical wording maintained next to source code, see:
 
-- [Platform plugins integration contract](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_CONTRACT.md)
-- [Integration QA checklist](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_QA_CHECKLIST.md)
+- [Shared technical contract](#shared-technical-contract) (this page)
+- [Verify payments](/build/guides/verify-payments) and [Handling webhooks](/build/advanced-guides/handling-webhooks)
 
 Before going live, also read [API integration](/start/first-payment), [Authentication](/api/authentication), and [Webhooks](/build/webhooks) for outbound subscription management.
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/magento.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/magento.fr.mdx
@@ -28,7 +28,7 @@ php bin/magento cache:flush
 
 Installation manuelle : copier le paquet sous `app/code/Lomi/Payments/` puis les mêmes commandes `module:enable` / `setup:upgrade`.
 
-Détails : [README du plugin Magento](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/magento/README.md)
+Détails : [README du plugin Magento](https://github.com/lomiafrica/magento/blob/main/README.md)
 
 ## Configuration
 
@@ -50,7 +50,7 @@ Détails : [README du plugin Magento](https://github.com/lomiafrica/lomi./blob/
 
 `GET /rest/V1/lomi/verify/{checkoutSessionId}`, vérifie la session pour la **dernière commande réelle** de la session checkout navigateur ; le segment d’URL doit correspondre à **`lomi_checkout_session_id`** sur cette commande.
 
-Défini dans [`etc/webapi.xml`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/magento/etc/webapi.xml).
+Défini dans [`etc/webapi.xml`](https://github.com/lomiafrica/magento/blob/main/etc/webapi.xml).
 
 ## Webhooks
 
@@ -58,8 +58,8 @@ Même contrat que les autres plugins PHP : HMAC-SHA256 hex sur le JSON **brut**
 
 ## Docs partagées
 
-- [Contrat d’intégration des plugins](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_CONTRACT.md)
-- [Liste de contrôle QA d’intégration](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_QA_CHECKLIST.md)
+- [Contrat technique partagé](/build/ecommerce-extensions#shared-technical-contract)
+- [Vérifier les paiements](/build/guides/verify-payments)
 
 ## Autres docs
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/magento.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/magento.mdx
@@ -28,7 +28,7 @@ php bin/magento cache:flush
 
 Manual install: copy package under `app/code/Lomi/Payments/` then run the same `module:enable` / `setup:upgrade` steps.
 
-Full instructions: [Magento plugin README](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/magento/README.md)
+Full instructions: [Magento plugin README](https://github.com/lomiafrica/magento/blob/main/README.md)
 
 ## Configuration
 
@@ -50,7 +50,7 @@ Full instructions: [Magento plugin README](https://github.com/lomiafrica/lomi./b
 
 `GET /rest/V1/lomi/verify/{checkoutSessionId}`, verifies the checkout session for the checkout session’s **last real order**; path segment must match **`lomi_checkout_session_id`** on that order.
 
-Defined in [`etc/webapi.xml`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/magento/etc/webapi.xml).
+Defined in [`etc/webapi.xml`](https://github.com/lomiafrica/magento/blob/main/etc/webapi.xml).
 
 ## Webhooks
 
@@ -58,8 +58,8 @@ Same contract as other PHP plugins: HMAC-SHA256 hex on **raw** JSON body; subscr
 
 ## Shared docs
 
-- [Platform plugins integration contract](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_CONTRACT.md)
-- [Integration QA checklist](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_QA_CHECKLIST.md)
+- [Shared technical contract](/build/ecommerce-extensions#shared-technical-contract)
+- [Verify payments](/build/guides/verify-payments)
 
 ## More docs
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/prestashop.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/prestashop.fr.mdx
@@ -7,7 +7,7 @@ description:
 
 # PrestaShop
 
-Module dans le dossier **`lomi/`** du monorepo : checkout hébergé via `POST /v1/checkout-sessions` et vérification via `GET /v1/checkout-sessions/{id}`.
+Module du dépôt [`lomiafrica/prestashop`](https://github.com/lomiafrica/prestashop) dans le dossier **`lomi/`** : checkout hébergé via `POST /v1/checkout-sessions` et vérification via `GET /v1/checkout-sessions/{id}`.
 
 ## Prérequis
 
@@ -16,12 +16,12 @@ Module dans le dossier **`lomi/`** du monorepo : checkout hébergé via `POST /
 
 ## Installation
 
-1. Zipper le dossier **`lomi`** depuis [`apps/plugins/prestashop/lomi`](https://github.com/lomiafrica/lomi./tree/master/apps/plugins/prestashop/lomi).
+1. Zipper le dossier **`lomi`** depuis le [dépôt prestashop](https://github.com/lomiafrica/prestashop/tree/main/lomi).
 2. **Back office → Modules → Importer un module**.
 3. Configurer les **clés secrètes** test / production, le **secret de signature webhook** et le **mode test**.
 4. L’URL webhook est affichée sur la page de configuration du module.
 
-Détails : [README du module PrestaShop](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/prestashop/lomi/README.md)
+Détails : [README du module PrestaShop](https://github.com/lomiafrica/prestashop/blob/main/lomi/README.md)
 
 ## URL webhook
 
@@ -36,12 +36,12 @@ Une **URL simplifiée** peut exposer le même contrôleur frontal du module.
 1. Le client choisit **Payer avec lomi.** → le contrôleur **validation** crée la session et redirige vers lomi. Checkout.
 2. Le contrôleur **callback** vérifie la session (id panier + secure key client), puis valide la commande PrestaShop si le statut est `completed` et que montant / devise correspondent.
 
-Sources : [`validation.php`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/prestashop/lomi/controllers/front/validation.php), [`callback.php`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/prestashop/lomi/controllers/front/callback.php), [`webhook.php`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/prestashop/lomi/controllers/front/webhook.php)
+Sources : [`validation.php`](https://github.com/lomiafrica/prestashop/blob/main/lomi/controllers/front/validation.php), [`callback.php`](https://github.com/lomiafrica/prestashop/blob/main/lomi/controllers/front/callback.php), [`webhook.php`](https://github.com/lomiafrica/prestashop/blob/main/lomi/controllers/front/webhook.php)
 
 ## Docs partagées
 
-- [Contrat d’intégration des plugins](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_CONTRACT.md)
-- [Liste de contrôle QA d’intégration](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_QA_CHECKLIST.md)
+- [Contrat technique partagé](/build/ecommerce-extensions#shared-technical-contract)
+- [Vérifier les paiements](/build/guides/verify-payments)
 
 ## Autres docs
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/prestashop.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/prestashop.mdx
@@ -7,7 +7,7 @@ description:
 
 # PrestaShop
 
-Module under **`lomi/`** in the monorepo: hosted checkout via `POST /v1/checkout-sessions` and verification via `GET /v1/checkout-sessions/{id}`.
+Module in the [`lomiafrica/prestashop`](https://github.com/lomiafrica/prestashop) repository under **`lomi/`**: hosted checkout via `POST /v1/checkout-sessions` and verification via `GET /v1/checkout-sessions/{id}`.
 
 ## Requirements
 
@@ -16,12 +16,12 @@ Module under **`lomi/`** in the monorepo: hosted checkout via `POST /v1/checkout
 
 ## Install
 
-1. Zip the **`lomi`** folder from [`apps/plugins/prestashop/lomi`](https://github.com/lomiafrica/lomi./tree/master/apps/plugins/prestashop/lomi).
+1. Zip the **`lomi`** folder from the [prestashop repository](https://github.com/lomiafrica/prestashop/tree/main/lomi).
 2. **Back office → Modules → Upload a module**.
 3. Configure **test/live secret keys**, **webhook signing secret**, and **test mode** switch.
 4. Webhook URL is displayed on the module configuration page.
 
-Detailed steps: [PrestaShop module README](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/prestashop/lomi/README.md)
+Detailed steps: [PrestaShop module README](https://github.com/lomiafrica/prestashop/blob/main/lomi/README.md)
 
 ## Webhook URL
 
@@ -36,12 +36,12 @@ Your shop may expose a **friendly URL** for the same controller, either works if
 1. Customer chooses **Pay with lomi.** → POST to **validation** controller creates the checkout session and redirects to lomi. Checkout.
 2. **callback** controller verifies the session (cart id + customer secure key), then validates the PrestaShop order when status is `completed` and amount/currency match.
 
-Source: [`validation.php`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/prestashop/lomi/controllers/front/validation.php), [`callback.php`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/prestashop/lomi/controllers/front/callback.php), [`webhook.php`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/prestashop/lomi/controllers/front/webhook.php)
+Source: [`validation.php`](https://github.com/lomiafrica/prestashop/blob/main/lomi/controllers/front/validation.php), [`callback.php`](https://github.com/lomiafrica/prestashop/blob/main/lomi/controllers/front/callback.php), [`webhook.php`](https://github.com/lomiafrica/prestashop/blob/main/lomi/controllers/front/webhook.php)
 
 ## Shared docs
 
-- [Platform plugins integration contract](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_CONTRACT.md)
-- [Integration QA checklist](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_QA_CHECKLIST.md)
+- [Shared technical contract](/build/ecommerce-extensions#shared-technical-contract)
+- [Verify payments](/build/guides/verify-payments)
 
 ## More docs
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/shopify.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/shopify.fr.mdx
@@ -21,6 +21,8 @@ L’app lomi. pour Shopify permet aux marchands d’accepter **Wave, mobile mone
 - Compte marchand lomi. avec **clé secrète API** et **secret de signature webhook**
 - Devise boutique prise en charge par lomi. (ex. **XOF**, **USD**, **EUR**)
 
+Distribution en **installation personnalisée** depuis le [tableau de bord lomi.](https://dashboard.lomi.africa) (pas de release publique sur GitHub).
+
 ## Installation
 
 ### Depuis le tableau de bord lomi. (recommandé)

--- a/apps/docs/content/docs/build/ecommerce-extensions/shopify.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/shopify.mdx
@@ -22,7 +22,7 @@ lomi. Shopify app lets merchants accept **Wave, mobile money, cards, and more** 
 - Store currency supported by lomi. (e.g. **XOF**, **USD**, **EUR**)
 - HTTPS on the app host (`connect.lomi.africa` in production)
 
-Source: [`apps/plugins/shopify`](https://github.com/lomiafrica/lomi./tree/master/apps/plugins/shopify)
+Distribution is via **custom install** from the [lomi. dashboard](https://dashboard.lomi.africa) (not a public GitHub release).
 
 ## Install (custom distribution)
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.fr.mdx
@@ -16,13 +16,20 @@ Extension WordPress qui envoie les acheteurs vers le **checkout hébergé lomi.*
 - Devise de la boutique **XOF**, **USD** ou **EUR**
 - HTTPS recommandé en production
 
-Source : [en-tête du plugin / readme](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/woo/woo-lomi.php)
+Source : [en-tête du plugin / readme](https://github.com/lomiafrica/woo/blob/main/woo-lomi.php)
 
 ## Installation
 
-1. Téléchargez ou clonez le plugin depuis [`apps/plugins/woo`](https://github.com/lomiafrica/lomi./tree/master/apps/plugins/woo).
-2. Placez le dossier dans `wp-content/plugins/` et activez **lomi. WooCommerce Payment Gateway** dans WordPress.
-3. Activez **WooCommerce** si ce n’est pas déjà fait.
+Téléchargez la dernière archive depuis les releases GitHub :
+
+[Télécharger woo-lomi.zip](https://github.com/lomiafrica/lomi./releases/latest/download/woo-lomi.zip)
+
+Les sources et les outils de build sont dans le [dépôt woo](https://github.com/lomiafrica/woo). Les releases pourront aussi y être publiées à terme.
+
+1. **Extensions WordPress → Ajouter → Téléverser** : choisissez `woo-lomi.zip` et activez.
+2. Les releases sont publiées sur les tags `woo-v*` (par ex. `woo-v1.002.0`). Le nom de l’asset reste **`woo-lomi.zip`** pour garder une URL `latest/download` stable.
+
+Pour compiler localement : clonez [lomiafrica/woo](https://github.com/lomiafrica/woo) puis `npm run release` (sortie dans `dist/woo-lomi-*.zip`).
 
 ## Liste de configuration
 
@@ -40,7 +47,7 @@ Source : [en-tête du plugin / readme](https://github.com/lomiafrica/lomi./blob/
 4. L’**URL de retour** appelle l’écouteur API WooCommerce, qui fait `GET /v1/checkout-sessions/{id}` et finalise la commande si le statut est `completed`.
 5. Le **webhook** `PAYMENT_SUCCEEDED` peut finaliser la commande si le retour navigateur est retardé ; signature vérifiée avec `X-Lomi-Signature` sur le corps brut.
 
-Référence code : [`class-wc-gateway-lomi.php`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/woo/includes/class-wc-gateway-lomi.php)
+Référence code : [`class-wc-gateway-lomi.php`](https://github.com/lomiafrica/woo/blob/main/includes/class-wc-gateway-lomi.php)
 
 ## Remboursements
 
@@ -63,13 +70,10 @@ Vérifier toujours les **octets bruts** reçus, ne pas re-sérialiser le JSON.
 
 Avant la prod :
 
-- [Liste de contrôle QA d’intégration](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_QA_CHECKLIST.md)
-
-Contrat technique (aligné Magento / Presta) :
-
-- [Contrat d’intégration des plugins](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_CONTRACT.md)
+- [Vérifier les paiements](/build/guides/verify-payments)
+- [Contrat technique partagé](/build/ecommerce-extensions#shared-technical-contract)
 
 ## Autres docs
 
 - [Hub extensions e‑commerce](/build/ecommerce-extensions)
-- Readme marchand (format WordPress.org) : [readme.txt](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/woo/readme.txt)
+- Readme marchand (format WordPress.org) : [readme.txt](https://github.com/lomiafrica/woo/blob/main/readme.txt)

--- a/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.mdx
@@ -16,7 +16,7 @@ WordPress plugin that redirects shoppers to **lomi. hosted checkout** and confir
 - Store currency **XOF**, **USD**, or **EUR** (gateway validates supported currencies)
 - HTTPS recommended for production
 
-Source: [plugin header / readme](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/woo/woo-lomi.php)
+Source: [plugin header / readme](https://github.com/lomiafrica/woo/blob/main/woo-lomi.php)
 
 ## Install
 
@@ -24,10 +24,12 @@ Download the latest plugin zip from GitHub Releases:
 
 [Download woo-lomi.zip](https://github.com/lomiafrica/lomi./releases/latest/download/woo-lomi.zip)
 
+Source and build tooling live in the [woo repository](https://github.com/lomiafrica/woo). Future releases may also be published from that repo.
+
 1. **WordPress Admin → Plugins → Add New → Upload Plugin**: choose `woo-lomi.zip` and activate.
 2. Releases are published on `woo-v*` tags (for example `woo-v1.002.0`). The asset name is always **`woo-lomi.zip`** so the `latest/download` URL stays stable.
 
-To build locally from the monorepo: `cd apps/plugins/woo && npm run release`.
+To build locally: clone [lomiafrica/woo](https://github.com/lomiafrica/woo) and run `npm run release` (output in `dist/woo-lomi-*.zip`).
 
 ## Setup checklist
 
@@ -48,7 +50,7 @@ To build locally from the monorepo: `cd apps/plugins/woo && npm run release`.
 5. **Webhook** `PAYMENT_SUCCEEDED` can finalize the order if the return URL is delayed; signature verified with `X-Lomi-Signature` over the raw body.
 6. On success the plugin stores **`_lomi_transaction_id`**, **`_lomi_subscription_id`** (subscriptions), and **`_lomi_price_id`** on the Woo order.
 
-Implementation reference: [`class-wc-gateway-lomi.php`](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/woo/includes/class-wc-gateway-lomi.php)
+Implementation reference: [`class-wc-gateway-lomi.php`](https://github.com/lomiafrica/woo/blob/main/includes/class-wc-gateway-lomi.php)
 
 ## Refunds
 
@@ -76,13 +78,10 @@ Always verify on the **exact raw bytes** received, do not re-stringify JSON.
 
 Use the shared checklist before production:
 
-- [Integration QA checklist](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_QA_CHECKLIST.md)
-
-Technical contract (aligned with Magento / Presta):
-
-- [Platform plugins integration contract](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/INTEGRATION_CONTRACT.md)
+- [Verify payments](/build/guides/verify-payments)
+- [Shared technical contract](/build/ecommerce-extensions#shared-technical-contract)
 
 ## More docs
 
 - [E‑commerce hub](/build/ecommerce-extensions)
-- Merchant-facing readme (WordPress.org format): [readme.txt](https://github.com/lomiafrica/lomi./blob/master/apps/plugins/woo/readme.txt)
+- Merchant-facing readme (WordPress.org format): [readme.txt](https://github.com/lomiafrica/woo/blob/main/readme.txt)

--- a/apps/docs/content/docs/resources/open-source/codebase.fr.mdx
+++ b/apps/docs/content/docs/resources/open-source/codebase.fr.mdx
@@ -20,7 +20,7 @@ Ce qui est ouvert aujourd’hui :
   - CLI (**`apps/cli`**), outil d’intégration ; s’appuyer sur l’API hébergée, pas sur l’exploitation plateforme
   - Service API : **`apps/api`**
   - SDK : **`apps/sdks`**
-  - Plugins e-commerce : **`apps/plugins`**
+  - Plugins e-commerce : dépôts séparés — [woo](https://github.com/lomiafrica/woo), [magento](https://github.com/lomiafrica/magento), [prestashop](https://github.com/lomiafrica/prestashop)
   - Serveur MCP (**`apps/mcp`**), outil d’intégration ; API marchande dans l’IDE, pas l’exploitation plateforme
   - Boilerplate événements (dépôt séparé) : **[lomiafrica/events](https://github.com/lomiafrica/events/)**
 

--- a/apps/docs/content/docs/resources/open-source/codebase.mdx
+++ b/apps/docs/content/docs/resources/open-source/codebase.mdx
@@ -20,7 +20,7 @@ What is open today:
   - CLI (**`apps/cli`**), integrator tool; build on the hosted API, not platform ops
   - API service: **`apps/api`**
   - SDKs: **`apps/sdks`**
-  - E-commerce plugins: **`apps/plugins`**
+  - E-commerce plugins: separate repos — [woo](https://github.com/lomiafrica/woo), [magento](https://github.com/lomiafrica/magento), [prestashop](https://github.com/lomiafrica/prestashop)
   - MCP server (**`apps/mcp`**), integrator tool; merchant API in your IDE, not platform ops
   - Events boilerplate (separate repo): **[lomiafrica/events](https://github.com/lomiafrica/events/)**
 


### PR DESCRIPTION
## Summary

- Point WooCommerce, Magento, and PrestaShop docs to standalone repos (`lomiafrica/woo`, `magento`, `prestashop`) instead of monorepo `apps/plugins` blob URLs that 404
- Replace links to missing `INTEGRATION_CONTRACT.md` / `INTEGRATION_QA_CHECKLIST.md` with internal docs (shared contract section, verify payments, handling webhooks)
- Shopify: remove broken GitHub link; document custom install via dashboard
- Add explicit `id="shared-technical-contract"` on EN/FR hub headings so cross-locale anchor links work
- Keep working `woo-lomi.zip` download URL on monorepo releases; source/build docs point at `lomiafrica/woo`
- Update open-source codebase page to list plugin repos instead of `apps/plugins`

Supersedes #33 with follow-up fixes (FR anchors, PrestaShop copy, no stale `apps/plugins/woo` build instructions).

## Test plan

- [ ] Open `/build/ecommerce-extensions` (EN + FR) and confirm shared-contract anchor links work
- [ ] Click Magento/PrestaShop/Woo source links — should resolve on GitHub
- [ ] Confirm Woo download link still serves `woo-lomi.zip`
- [ ] Shopify page no longer links to missing `apps/plugins/shopify`


Made with [Cursor](https://cursor.com)