### PR TITLE
docs: strengthen onboarding spine links and navigation hubs

### DIFF
--- a/apps/docs/content/docs/build/choose-integration.fr.mdx
+++ b/apps/docs/content/docs/build/choose-integration.fr.mdx
@@ -62,14 +62,24 @@ Toute intégration sérieuse doit inclure :
 - Webhooks pour la réconciliation finale.
 - Idempotence sur les opérations de création lorsque des retries sont possibles.
 
+Avant le go-live, exécutez [Simuler des erreurs](/build/guides/simulate-errors) en sandbox pour tester échecs et états en attente.
+
 ## Étapes suivantes
 
+**Onboarding**
+
 - [Parcours d’intégration](/start/integration-journey)
-- [Canaux de paiement](/build/payment-channels)
+- [Faire un paiement de test](/start/first-payment)
+- [Paiements sandbox](/start/sandbox-payments)
+- [Simuler des erreurs](/build/guides/simulate-errors)
+
+**Build**
+
+- [Checkout hébergé](/build/checkout) · [Produits](/build/products) · [Canaux de paiement](/build/payment-channels)
+- [Webhooks](/build/webhooks) · [Vérifier les paiements](/build/guides/verify-payments)
+
+**Exemples & API**
+
 - [Exemple checkout hébergé](https://github.com/lomiafrica/lomi./tree/main/apps/plugins/payment-integration-sdk-reference)
 - [Exemple charge directe](https://github.com/lomiafrica/lomi./tree/main/apps/plugins/direct-charge-integration-reference)
-- [Faire un paiement de test](/start/first-payment)
-- [Vérifier les paiements](/build/guides/verify-payments)
-- [Checkout hébergé](/build/checkout)
-- [Webhooks](/build/webhooks)
 - [Référence API](/api)

--- a/apps/docs/content/docs/build/choose-integration.mdx
+++ b/apps/docs/content/docs/build/choose-integration.mdx
@@ -62,14 +62,24 @@ Every serious integration should include:
 - Webhook handling for final reconciliation.
 - Idempotency for create-style payment operations when retries are possible.
 
+Before go-live, run [Simulate errors](/build/guides/simulate-errors) in sandbox to exercise failure and pending states.
+
 ## Next steps
 
+**Onboarding**
+
 - [Integration journey](/start/integration-journey)
-- [Payment channels](/build/payment-channels)
+- [Make a test payment](/start/first-payment)
+- [Sandbox payments](/start/sandbox-payments)
+- [Simulate errors](/build/guides/simulate-errors)
+
+**Build**
+
+- [Hosted checkout](/build/checkout) · [Products](/build/products) · [Payment channels](/build/payment-channels)
+- [Webhooks](/build/webhooks) · [Verify payments](/build/guides/verify-payments)
+
+**Reference apps & API**
+
 - [Hosted checkout reference app](https://github.com/lomiafrica/lomi./tree/main/apps/plugins/payment-integration-sdk-reference)
 - [Direct charge reference app](https://github.com/lomiafrica/lomi./tree/main/apps/plugins/direct-charge-integration-reference)
-- [Make a test payment](/start/first-payment)
-- [Verify payments](/build/guides/verify-payments)
-- [Hosted checkout](/build/checkout)
-- [Webhooks](/build/webhooks)
 - [API reference](/api)

--- a/apps/docs/content/docs/build/ecommerce-extensions/index.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/index.fr.mdx
@@ -13,7 +13,7 @@ import { Callout } from '@/components/docs/docs-callout';
 
 Installez lomi. sur votre boutique sans recoder le tunnel de paiement. Ces modules créent des **sessions de paiement hébergées**, envoient le client vers la **page lomi. Checkout**, puis confirment le paiement via les **URL de retour** et les **webhooks marchands**.
 
-<h2 id="shared-technical-contract">Contrat technique partagé</h2>
+## Contrat technique partagé
 
 WooCommerce, Magento 2 et PrestaShop n’utilent que l’**API REST publique** lomi. (`/v1/checkout-sessions`). Ils **n’appellent pas** les RPC Supabase ni les endpoints internes Nest.
 
@@ -28,7 +28,7 @@ WooCommerce, Magento 2 et PrestaShop n’utilent que l’**API REST publique** 
 
 Formulation canonique à côté du code :
 
-- [Contrat technique partagé](#shared-technical-contract) (cette page)
+- [Contrat technique partagé](#contrat-technique-partagé) (cette page)
 - [Vérifier les paiements](/build/guides/verify-payments) et [Traiter les webhooks](/build/advanced-guides/handling-webhooks)
 
 Avant la mise en production : [Intégration API](/start/first-payment), [Authentification](/api/authentication) et [Webhooks](/build/webhooks).

--- a/apps/docs/content/docs/build/ecommerce-extensions/index.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/index.mdx
@@ -13,7 +13,7 @@ import { Callout } from '@/components/docs/docs-callout';
 
 Install lomi. on your store without writing checkout plumbing yourself. These modules create **hosted checkout sessions**, redirect shoppers to lomi. Checkout, then confirm payment via **return URLs** and **merchant webhooks**.
 
-<h2 id="shared-technical-contract">Shared technical contract</h2>
+## Shared technical contract
 
 WooCommerce, Magento 2, and PrestaShop talk only to lomi.’s **public REST API** (`/v1/checkout-sessions`). They do **not** call Supabase RPC or internal-only Nest endpoints.
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/magento.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/magento.fr.mdx
@@ -58,7 +58,7 @@ Même contrat que les autres plugins PHP : HMAC-SHA256 hex sur le JSON **brut**
 
 ## Docs partagées
 
-- [Contrat technique partagé](/build/ecommerce-extensions#shared-technical-contract)
+- [Contrat technique partagé](/build/ecommerce-extensions)
 - [Vérifier les paiements](/build/guides/verify-payments)
 
 ## Autres docs

--- a/apps/docs/content/docs/build/ecommerce-extensions/magento.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/magento.mdx
@@ -58,7 +58,7 @@ Same contract as other PHP plugins: HMAC-SHA256 hex on **raw** JSON body; subscr
 
 ## Shared docs
 
-- [Shared technical contract](/build/ecommerce-extensions#shared-technical-contract)
+- [Shared technical contract](/build/ecommerce-extensions)
 - [Verify payments](/build/guides/verify-payments)
 
 ## More docs

--- a/apps/docs/content/docs/build/ecommerce-extensions/prestashop.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/prestashop.fr.mdx
@@ -40,7 +40,7 @@ Sources : [`validation.php`](https://github.com/lomiafrica/prestashop/blob/main
 
 ## Docs partagées
 
-- [Contrat technique partagé](/build/ecommerce-extensions#shared-technical-contract)
+- [Contrat technique partagé](/build/ecommerce-extensions)
 - [Vérifier les paiements](/build/guides/verify-payments)
 
 ## Autres docs

--- a/apps/docs/content/docs/build/ecommerce-extensions/prestashop.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/prestashop.mdx
@@ -40,7 +40,7 @@ Source: [`validation.php`](https://github.com/lomiafrica/prestashop/blob/main/lo
 
 ## Shared docs
 
-- [Shared technical contract](/build/ecommerce-extensions#shared-technical-contract)
+- [Shared technical contract](/build/ecommerce-extensions)
 - [Verify payments](/build/guides/verify-payments)
 
 ## More docs

--- a/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.fr.mdx
@@ -71,7 +71,7 @@ Vérifier toujours les **octets bruts** reçus, ne pas re-sérialiser le JSON.
 Avant la prod :
 
 - [Vérifier les paiements](/build/guides/verify-payments)
-- [Contrat technique partagé](/build/ecommerce-extensions#shared-technical-contract)
+- [Contrat technique partagé](/build/ecommerce-extensions)
 
 ## Autres docs
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.mdx
@@ -79,7 +79,7 @@ Always verify on the **exact raw bytes** received, do not re-stringify JSON.
 Use the shared checklist before production:
 
 - [Verify payments](/build/guides/verify-payments)
-- [Shared technical contract](/build/ecommerce-extensions#shared-technical-contract)
+- [Shared technical contract](/build/ecommerce-extensions)
 
 ## More docs
 

--- a/apps/docs/content/docs/start/integration-journey.fr.mdx
+++ b/apps/docs/content/docs/start/integration-journey.fr.mdx
@@ -32,17 +32,24 @@ Voir [Créer votre compte](/start/create-account) et [Clés API](/start/api-keys
 | Besoin | Commencez par |
 | --- | --- |
 | Page checkout complète | [Checkout hébergé](/build/checkout) |
+| Checkout intégré sur votre site | [Widget checkout](/build/embed-widget) |
 | URL partageable | [Liens de paiement](/build/payment-links) |
+| Demande de paiement créée côté backend | [Demandes de paiement](/build/payment-requests) |
 | Mobile money ou cartes côté serveur | [Charges directes](/build/direct-charges) |
 | Facturation récurrente | [Abonnements](/build/subscriptions) |
+| Plugin boutique (WooCommerce, Shopify, etc.) | [Extensions ecommerce](/build/ecommerce-extensions) |
 
-La plupart des équipes commencent par le **checkout hébergé**. Consultez [Quelle intégration choisir ?](/build/choose-integration) et [Canaux de paiement](/build/payment-channels).
+Définissez ce que vous vendez dans [Produits](/build/products) avant de créer des sessions checkout ou des plans d’abonnement.
+
+La plupart des équipes commencent par le **checkout hébergé**. Consultez [Quelle intégration choisir ?](/build/choose-integration) et le [hub moyens de paiement](/build/guides/payment-methods). Pour une matrice pays × canal, voir [Canaux de paiement](/build/payment-channels).
 
 ## Étape 3: Tester de bout en bout
 
 1. [Faire un paiement de test](/start/first-payment)
 2. [Paiements sandbox](/start/sandbox-payments): cartes, Wave, MTN
-3. [Gestion des erreurs](/build/advanced-guides/error-handling) et [idempotence](/build/advanced-guides/idempotency-keys)
+3. Tester les échecs avec [Simuler des erreurs](/build/guides/simulate-errors)
+4. [Gestion des erreurs](/build/advanced-guides/error-handling) et [idempotence](/build/advanced-guides/idempotency-keys)
+5. Cas limites checkout (abonnements, essais, mobile money en attente) : [Comportement checkout](/build/payments/checkout-behavior) et guides par moyen sous [Moyens de paiement](/build/payment-methods)
 
 ## Étape 4: Configurer les webhooks
 
@@ -62,7 +69,26 @@ Les webhooks sont essentiels pour les moyens de paiement et les événements hor
 
 ## Étapes suivantes
 
+### Confirmer les paiements en production
+
 - [Vérifier les paiements](/build/guides/verify-payments)
 - [Cycle de vie des paiements](/build/guides/payment-lifecycle)
-- [Démarrer avec le CLI](/start/cli-quickstart)
 - [Machine à états des paiements](/api/payment-state-machine)
+
+### Exploiter après le go-live
+
+- [Transactions](/build/transactions) · [Remboursements](/build/refunds) · [Reversements](/build/payouts) · [Litiges](/build/disputes)
+- [Solde et règlement](/build/balance-and-settlement) · [Radar (fraude)](/build/radar)
+
+### Catalogue, facturation et clients
+
+- [Produits](/build/products) · [Facturation à l’usage](/build/usage-billing) · [Coupons](/build/discount-coupons)
+- [Portail client](/build/customer-portal) · [Clients](/build/platform/customers)
+- [Marchands](/build/platform/merchants) · [Organisations](/build/platform/organizations)
+
+### Outils et durcissement
+
+- [SDKs](/build/sdks) · [CLI](/build/cli) · [MCP](/build/mcp) · [lomi. UI](/build/lomi-ui)
+- [Extensions ecommerce](/build/ecommerce-extensions) (WooCommerce, Shopify, Magento, PrestaShop)
+- [Guides avancés](/build/advanced-guides) (erreurs, tests, CI/CD, fiabilité webhooks)
+- [Démarrer avec le CLI](/start/cli-quickstart)

--- a/apps/docs/content/docs/start/integration-journey.fr.mdx
+++ b/apps/docs/content/docs/start/integration-journey.fr.mdx
@@ -37,7 +37,7 @@ Voir [Créer votre compte](/start/create-account) et [Clés API](/start/api-keys
 | Demande de paiement créée côté backend | [Demandes de paiement](/build/payment-requests) |
 | Mobile money ou cartes côté serveur | [Charges directes](/build/direct-charges) |
 | Facturation récurrente | [Abonnements](/build/subscriptions) |
-| Plugin boutique (WooCommerce, Shopify, etc.) | [Extensions ecommerce](/build/ecommerce-extensions) |
+| Plugin boutique (WooCommerce, Shopify, etc.) | [Extensions e‑commerce](/build/ecommerce-extensions) |
 
 Définissez ce que vous vendez dans [Produits](/build/products) avant de créer des sessions checkout ou des plans d’abonnement.
 
@@ -49,7 +49,7 @@ La plupart des équipes commencent par le **checkout hébergé**. Consultez [Que
 2. [Paiements sandbox](/start/sandbox-payments): cartes, Wave, MTN
 3. Tester les échecs avec [Simuler des erreurs](/build/guides/simulate-errors)
 4. [Gestion des erreurs](/build/advanced-guides/error-handling) et [idempotence](/build/advanced-guides/idempotency-keys)
-5. Cas limites checkout (abonnements, essais, mobile money en attente) : [Comportement checkout](/build/payments/checkout-behavior) et guides par moyen sous [Moyens de paiement](/build/payment-methods)
+5. Cas limites checkout (abonnements, essais, mobile money en attente) : [Comportement checkout](/build/payments/checkout-behavior) et guides par moyen sous [Moyens de paiement](/build/guides/payment-methods)
 
 ## Étape 4: Configurer les webhooks
 
@@ -89,6 +89,6 @@ Les webhooks sont essentiels pour les moyens de paiement et les événements hor
 ### Outils et durcissement
 
 - [SDKs](/build/sdks) · [CLI](/build/cli) · [MCP](/build/mcp) · [lomi. UI](/build/lomi-ui)
-- [Extensions ecommerce](/build/ecommerce-extensions) (WooCommerce, Shopify, Magento, PrestaShop)
+- [Extensions e‑commerce](/build/ecommerce-extensions) (WooCommerce, Shopify, Magento, PrestaShop)
 - [Guides avancés](/build/advanced-guides) (erreurs, tests, CI/CD, fiabilité webhooks)
 - [Démarrer avec le CLI](/start/cli-quickstart)

--- a/apps/docs/content/docs/start/integration-journey.mdx
+++ b/apps/docs/content/docs/start/integration-journey.mdx
@@ -53,7 +53,7 @@ Test your integration thoroughly using sandbox credentials:
 2. Use [Sandbox payments](/start/sandbox-payments) for test cards, Wave, and MTN behavior.
 3. Exercise failure paths with [Simulate errors](/build/guides/simulate-errors).
 4. Fix issues using [Error handling](/build/advanced-guides/error-handling) and [Idempotency keys](/build/advanced-guides/idempotency-keys).
-5. For checkout edge cases (subscriptions, trials, pending mobile money), see [Checkout behavior](/build/payments/checkout-behavior) and per-method guides under [Payment methods](/build/payment-methods).
+5. For checkout edge cases (subscriptions, trials, pending mobile money), see [Checkout behavior](/build/payments/checkout-behavior) and per-method guides under [Payment methods](/build/guides/payment-methods).
 
 ## Step 4: Configure webhooks
 

--- a/apps/docs/content/docs/start/integration-journey.mdx
+++ b/apps/docs/content/docs/start/integration-journey.mdx
@@ -34,11 +34,16 @@ lomi. supports multiple integration options depending on your stack:
 | If you need | Start with |
 | --- | --- |
 | A complete checkout page | [Hosted checkout](/build/checkout) |
+| Checkout embedded on your site | [Embed checkout widget](/build/embed-widget) |
 | A shareable URL | [Payment links](/build/payment-links) |
+| A backend-created payment request | [Payment requests](/build/payment-requests) |
 | Server-initiated mobile money or embedded cards | [Direct charges](/build/direct-charges) |
 | Recurring billing | [Subscriptions](/build/subscriptions) via checkout or links |
+| Store plugin (WooCommerce, Shopify, etc.) | [E-commerce extensions](/build/ecommerce-extensions) |
 
-Most teams should start with **hosted checkout**. Use [Which payment integration should I choose?](/build/choose-integration) and the [payment methods hub](/build/guides/payment-methods) to confirm Wave, MTN, and card coverage for your markets.
+Define what you sell in [Products](/build/products) before you create checkout sessions or subscription plans.
+
+Most teams should start with **hosted checkout**. Use [Which payment integration should I choose?](/build/choose-integration) and the [payment methods hub](/build/guides/payment-methods) to confirm Wave, MTN, and card coverage for your markets. For a country × channel matrix, see [Payment channels](/build/payment-channels).
 
 ## Step 3: Test end-to-end
 
@@ -46,7 +51,9 @@ Test your integration thoroughly using sandbox credentials:
 
 1. [Make a test payment](/start/first-payment): CLI or API checkout session.
 2. Use [Sandbox payments](/start/sandbox-payments) for test cards, Wave, and MTN behavior.
-3. Fix issues using [Error handling](/build/advanced-guides/error-handling) and [Idempotency keys](/build/advanced-guides/idempotency-keys).
+3. Exercise failure paths with [Simulate errors](/build/guides/simulate-errors).
+4. Fix issues using [Error handling](/build/advanced-guides/error-handling) and [Idempotency keys](/build/advanced-guides/idempotency-keys).
+5. For checkout edge cases (subscriptions, trials, pending mobile money), see [Checkout behavior](/build/payments/checkout-behavior) and per-method guides under [Payment methods](/build/payment-methods).
 
 ## Step 4: Configure webhooks
 
@@ -68,7 +75,26 @@ When sandbox flows pass your checklist:
 
 ## Next steps
 
+### Confirm payments in production
+
 - [Verify payments](/build/guides/verify-payments)
 - [Payment lifecycle](/build/guides/payment-lifecycle)
-- [CLI quickstart](/start/cli-quickstart)
 - [Payment state machine](/api/payment-state-machine)
+
+### Operate after go-live
+
+- [Transactions](/build/transactions) · [Refunds](/build/refunds) · [Payouts](/build/payouts) · [Disputes](/build/disputes)
+- [Balance and settlement](/build/balance-and-settlement) · [Radar (fraud)](/build/radar)
+
+### Catalog, billing, and customers
+
+- [Products](/build/products) · [Usage billing](/build/usage-billing) · [Discount coupons](/build/discount-coupons)
+- [Customer portal](/build/customer-portal) · [Customers](/build/platform/customers)
+- [Merchants](/build/platform/merchants) · [Organizations](/build/platform/organizations)
+
+### Tools and hardening
+
+- [SDKs](/build/sdks) · [CLI](/build/cli) · [MCP](/build/mcp) · [lomi. UI](/build/lomi-ui)
+- [E-commerce extensions](/build/ecommerce-extensions) (WooCommerce, Shopify, Magento, PrestaShop)
+- [Advanced guides](/build/advanced-guides) (error handling, testing, CI/CD, webhook reliability)
+- [CLI quickstart](/start/cli-quickstart)

--- a/apps/docs/content/docs/start/overview.fr.mdx
+++ b/apps/docs/content/docs/start/overview.fr.mdx
@@ -51,8 +51,11 @@ La plupart des équipes commencent par l’un de ces chemins :
 | Accepter un premier paiement en ligne | [Faire un paiement de test](/start/first-payment) |
 | Ajouter un checkout à une app ou boutique | [Checkout hébergé](/build/checkout) |
 | Vendre sans coder un checkout complet | [Liens de paiement](/build/payment-links) |
+| Définir le catalogue avant le checkout | [Produits](/build/products) |
 | Comparer les options d’intégration | [Choisir une intégration](/build/choose-integration) |
 | Connecter votre backend aux événements | [Webhooks](/build/webhooks) |
+| Laisser les clients gérer la facturation | [Portail client](/build/customer-portal) |
+| Boutique WooCommerce ou Shopify | [Extensions ecommerce](/build/ecommerce-extensions) |
 
 ## Comment la plateforme s’assemble ?
 
@@ -69,8 +72,16 @@ La référence API donne les détails exacts des requêtes et réponses. Les gui
 
 ## Que lire ensuite ?
 
+**Onboarding**
+
 - [Parcours d’intégration](/start/integration-journey)
 - [Créer un compte](/start/create-account)
 - [Trouver vos clés API](/start/api-keys)
 - [Faire un paiement de test](/start/first-payment)
 - [Tester en sécurité dans la sandbox](/start/sandbox-payments)
+
+**Après le premier paiement**
+
+- [Choisir une intégration](/build/choose-integration) · [Produits](/build/products) · [SDKs](/build/sdks)
+- [Simuler des erreurs](/build/guides/simulate-errors) · [Comportement checkout](/build/payments/checkout-behavior)
+- [Transactions](/build/transactions) · [Remboursements](/build/refunds) · [Reversements](/build/payouts) · [Radar](/build/radar)

--- a/apps/docs/content/docs/start/overview.fr.mdx
+++ b/apps/docs/content/docs/start/overview.fr.mdx
@@ -55,7 +55,7 @@ La plupart des équipes commencent par l’un de ces chemins :
 | Comparer les options d’intégration | [Choisir une intégration](/build/choose-integration) |
 | Connecter votre backend aux événements | [Webhooks](/build/webhooks) |
 | Laisser les clients gérer la facturation | [Portail client](/build/customer-portal) |
-| Boutique WooCommerce ou Shopify | [Extensions ecommerce](/build/ecommerce-extensions) |
+| Boutique WooCommerce ou Shopify | [Extensions e‑commerce](/build/ecommerce-extensions) |
 
 ## Comment la plateforme s’assemble ?
 

--- a/apps/docs/content/docs/start/overview.mdx
+++ b/apps/docs/content/docs/start/overview.mdx
@@ -51,8 +51,11 @@ Most teams should start with one of these paths:
 | Accept a first online payment | [Make a test payment](/start/first-payment) |
 | Add checkout to an app or store | [Hosted checkout](/build/checkout) |
 | Sell without writing checkout code | [Payment links](/build/payment-links) |
+| Define your catalog before checkout | [Products](/build/products) |
 | Compare every integration option | [Choose an integration](/build/choose-integration) |
 | Connect your backend to events | [Webhooks](/build/webhooks) |
+| Let customers manage billing | [Customer portal](/build/customer-portal) |
+| WooCommerce or Shopify store | [E-commerce extensions](/build/ecommerce-extensions) |
 
 ## How does the platform fit together?
 
@@ -69,8 +72,16 @@ The API reference has exact request and response details. The Build guides expla
 
 ## What should I read next?
 
+**Onboarding**
+
 - [Integration journey](/start/integration-journey)
 - [Create an account](/start/create-account)
 - [Find your API keys](/start/api-keys)
 - [Make a test payment](/start/first-payment)
 - [Test safely in sandbox](/start/sandbox-payments)
+
+**After your first payment works**
+
+- [Choose an integration](/build/choose-integration) · [Products](/build/products) · [SDKs](/build/sdks)
+- [Simulate errors](/build/guides/simulate-errors) · [Checkout behavior](/build/payments/checkout-behavior)
+- [Transactions](/build/transactions) · [Refunds](/build/refunds) · [Payouts](/build/payouts) · [Radar](/build/radar)

--- a/apps/docs/eslint.config.mjs
+++ b/apps/docs/eslint.config.mjs
@@ -30,7 +30,7 @@ const eslintConfig = [
     },
   },
   {
-    files: ['**/*.js'],
+    files: ['**/*.js', '**/*.mjs'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',

--- a/apps/docs/lib/scripts/audit-spine-links.mjs
+++ b/apps/docs/lib/scripts/audit-spine-links.mjs
@@ -15,24 +15,6 @@ const SPINE_FILES = [
 
 const linkRe = /\]\(\/(start|build|resources)\/([^)\s#]+)/g;
 
-function walk(dir, acc = []) {
-  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
-    const p = path.join(dir, ent.name);
-    if (ent.isDirectory()) walk(p, acc);
-    else if (
-      ent.name.endsWith('.mdx') &&
-      !/\.(fr|es|zh)\.mdx$/.test(ent.name)
-    ) {
-      acc.push(p);
-    }
-  }
-  return acc;
-}
-
-function slugFromAbs(abs) {
-  return path.relative(CONTENT, abs).split(path.sep).join('/').replace(/\.mdx$/, '');
-}
-
 function expandSidebar(pages, prefix) {
   const out = [];
   for (const p of pages) {

--- a/apps/docs/lib/scripts/audit-spine-links.mjs
+++ b/apps/docs/lib/scripts/audit-spine-links.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/** One-off audit: spine pages vs sidebar. Run: node lib/scripts/audit-spine-links.mjs */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DOCS_ROOT = process.cwd();
+const CONTENT = path.join(DOCS_ROOT, 'content/docs');
+
+const SPINE_FILES = [
+  'start/overview.mdx',
+  'start/integration-journey.mdx',
+  'build/choose-integration.mdx',
+];
+
+const linkRe = /\]\(\/(start|build|resources)\/([^)\s#]+)/g;
+
+function walk(dir, acc = []) {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, ent.name);
+    if (ent.isDirectory()) walk(p, acc);
+    else if (
+      ent.name.endsWith('.mdx') &&
+      !/\.(fr|es|zh)\.mdx$/.test(ent.name)
+    ) {
+      acc.push(p);
+    }
+  }
+  return acc;
+}
+
+function slugFromAbs(abs) {
+  return path.relative(CONTENT, abs).split(path.sep).join('/').replace(/\.mdx$/, '');
+}
+
+function expandSidebar(pages, prefix) {
+  const out = [];
+  for (const p of pages) {
+    if (p.startsWith('---')) continue;
+    out.push(`${prefix}/${p}`);
+    if (!p.includes('/')) {
+      const sub = path.join(CONTENT, prefix, p, 'meta.json');
+      if (fs.existsSync(sub)) {
+        const subMeta = JSON.parse(fs.readFileSync(sub, 'utf8'));
+        out.push(...expandSidebar(subMeta.pages ?? [], `${prefix}/${p}`));
+      }
+    }
+  }
+  return out;
+}
+
+function linked(slug, spineLinks) {
+  if (spineLinks.has(slug)) return true;
+  if (slug.endsWith('/index') && spineLinks.has(slug.slice(0, -'/index'.length))) {
+    return true;
+  }
+  return false;
+}
+
+const spineLinks = new Set();
+for (const rel of SPINE_FILES) {
+  for (const v of [rel, rel.replace('.mdx', '.fr.mdx')]) {
+    const filePath = path.join(CONTENT, v);
+    if (!fs.existsSync(filePath)) continue;
+    const content = fs.readFileSync(filePath, 'utf8');
+    for (const match of content.matchAll(linkRe)) {
+      spineLinks.add(`${match[1]}/${match[2]}`);
+    }
+  }
+}
+
+const buildMeta = JSON.parse(
+  fs.readFileSync(path.join(CONTENT, 'build/meta.json'), 'utf8'),
+);
+const startMeta = JSON.parse(
+  fs.readFileSync(path.join(CONTENT, 'start/meta.json'), 'utf8'),
+);
+
+const sidebar = new Set([
+  ...expandSidebar(startMeta.pages, 'start'),
+  ...expandSidebar(buildMeta.pages, 'build'),
+]);
+
+const inSidebarNotSpine = [...sidebar]
+  .filter((s) => !linked(s, spineLinks))
+  .sort();
+
+console.log(`Spine links: ${spineLinks.size}`);
+console.log(`Sidebar items not in spine: ${inSidebarNotSpine.length}\n`);
+for (const s of inSidebarNotSpine) {
+  console.log(`  ${s}`);
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -23,6 +23,7 @@
     "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev --turbo",
     "lint": "fumadocs-mdx && bun ./lib/scripts/lint.ts && bun ./lib/scripts/check-mdx-sdk-snippets.ts && pnpm exec tsx lib/scripts/manual-api/verify-en-operation-overrides.ts && eslint .",
     "docs:drift": "pnpm exec tsx lib/scripts/docs-drift.ts",
+    "docs:audit-spine": "node lib/scripts/audit-spine-links.mjs",
     "api:bootstrap": "pnpm exec tsx lib/scripts/bootstrap-manual-api-reference.ts",
     "api:regenerate-rest-reference": "pnpm exec tsx lib/scripts/bootstrap-manual-api-reference.ts",
     "knip": "knip",


### PR DESCRIPTION
## Summary

Improves how integrators discover Build guides from the onboarding spine. Connects overview, integration-journey, and choose-integration to key build guides (products, ops, tools) and adds `pnpm docs:audit-spine`.

Supersedes #32 with CI fixes:
- `/build/payment-methods` → `/build/guides/payment-methods` (no index page at former)
- E-commerce hub cross-links lint cleanly (no invalid fragments)
- ESLint passes for `audit-spine-links.mjs`

## Test plan

- [x] `pnpm lint` in apps/docs passes
- [ ] `/start/integration-journey` links resolve in preview
- [ ] `pnpm docs:audit-spine` runs without error


Made with [Cursor](https://cursor.com)