### PR TITLE
docs: clarify e-commerce plugin install paths

### DIFF
--- a/apps/docs/content/docs/build/ecommerce-extensions/index.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/index.fr.mdx
@@ -33,6 +33,15 @@ Formulation canonique à côté du code :
 
 Avant la mise en production : [Intégration API](/start/first-payment), [Authentification](/api/authentication) et [Webhooks](/build/webhooks).
 
+## Où télécharger chaque extension
+
+| Plateforme | Artefact d’installation |
+| --- | --- |
+| WooCommerce | `woo-lomi.zip` via les [releases lomi.](https://github.com/lomiafrica/lomi./releases?q=woo-v&expanded=true) (tags `woo-v*`) ou build depuis [woo](https://github.com/lomiafrica/woo) |
+| Magento 2 | Composer VCS depuis [magento](https://github.com/lomiafrica/magento) ou copie dans `app/code/Lomi/Payments/` |
+| PrestaShop | Zip du dossier `lomi/` depuis [prestashop](https://github.com/lomiafrica/prestashop) |
+| Shopify | [Tableau de bord](https://dashboard.lomi.africa) → **Paramètres → Canaux de paiement → Intégrations** (installation personnalisée, pas de zip) |
+
 ## Choisir la plateforme
 
 <Cards>

--- a/apps/docs/content/docs/build/ecommerce-extensions/index.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/index.mdx
@@ -33,6 +33,15 @@ For the canonical wording maintained next to source code, see:
 
 Before going live, also read [API integration](/start/first-payment), [Authentication](/api/authentication), and [Webhooks](/build/webhooks) for outbound subscription management.
 
+## Where to get each plugin
+
+| Platform | Install artifact |
+| --- | --- |
+| WooCommerce | `woo-lomi.zip` from [lomi. releases](https://github.com/lomiafrica/lomi./releases?q=woo-v&expanded=true) (`woo-v*` tags) or build from [woo](https://github.com/lomiafrica/woo) |
+| Magento 2 | Composer VCS from [magento](https://github.com/lomiafrica/magento) or copy to `app/code/Lomi/Payments/` |
+| PrestaShop | Zip the `lomi/` folder from [prestashop](https://github.com/lomiafrica/prestashop) |
+| Shopify | [Dashboard](https://dashboard.lomi.africa) → **Settings → Payment channels → Integrations** (custom install, no zip) |
+
 ## Choose your platform
 
 <Cards>

--- a/apps/docs/content/docs/build/ecommerce-extensions/magento.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/magento.fr.mdx
@@ -16,17 +16,23 @@ Extension **Lomi_Payments** pour Magento Open Source / Adobe Commerce. Code du m
 
 ## Installation
 
-Composer (cas courant) :
+`lomi/magento2-payments` **n’est pas publié sur Packagist**. Enregistrez le dépôt GitHub, puis installez avec Composer :
 
 ```bash
+composer config repositories.lomi-magento vcs https://github.com/lomiafrica/magento
 composer require lomi/magento2-payments
 php bin/magento module:enable Lomi_Payments
 php bin/magento setup:upgrade
 php bin/magento setup:di:compile
+php bin/magento setup:static-content:deploy -f
 php bin/magento cache:flush
 ```
 
-Installation manuelle : copier le paquet sous `app/code/Lomi/Payments/` puis les mêmes commandes `module:enable` / `setup:upgrade`.
+### Installation manuelle
+
+1. Clonez ou téléchargez [lomiafrica/magento](https://github.com/lomiafrica/magento).
+2. Copiez le paquet dans `app/code/Lomi/Payments/` à la racine Magento (dossier contenant `registration.php`).
+3. Exécutez les mêmes commandes `module:enable`, `setup:upgrade`, `setup:di:compile` et `cache:flush` que ci-dessus.
 
 Détails : [README du plugin Magento](https://github.com/lomiafrica/magento/blob/main/README.md)
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/magento.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/magento.mdx
@@ -16,17 +16,23 @@ Extension **Lomi_Payments** for Magento Open Source / Adobe Commerce. Payment me
 
 ## Installation
 
-Composer (typical):
+`lomi/magento2-payments` is **not published on Packagist**. Register the GitHub repository, then install with Composer:
 
 ```bash
+composer config repositories.lomi-magento vcs https://github.com/lomiafrica/magento
 composer require lomi/magento2-payments
 php bin/magento module:enable Lomi_Payments
 php bin/magento setup:upgrade
 php bin/magento setup:di:compile
+php bin/magento setup:static-content:deploy -f
 php bin/magento cache:flush
 ```
 
-Manual install: copy package under `app/code/Lomi/Payments/` then run the same `module:enable` / `setup:upgrade` steps.
+### Manual install
+
+1. Clone or download [lomiafrica/magento](https://github.com/lomiafrica/magento).
+2. Copy the package to `app/code/Lomi/Payments/` on your Magento root (the directory that contains `registration.php`).
+3. Run the same `module:enable`, `setup:upgrade`, `setup:di:compile`, and `cache:flush` commands as above.
 
 Full instructions: [Magento plugin README](https://github.com/lomiafrica/magento/blob/main/README.md)
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/prestashop.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/prestashop.fr.mdx
@@ -16,10 +16,12 @@ Module du dépôt [`lomiafrica/prestashop`](https://github.com/lomiafrica/presta
 
 ## Installation
 
-1. Zipper le dossier **`lomi`** depuis le [dépôt prestashop](https://github.com/lomiafrica/prestashop/tree/main/lomi).
-2. **Back office → Modules → Importer un module**.
-3. Configurer les **clés secrètes** test / production, le **secret de signature webhook** et le **mode test**.
-4. L’URL webhook est affichée sur la page de configuration du module.
+1. Ouvrez le dossier **`lomi`** dans [lomiafrica/prestashop](https://github.com/lomiafrica/prestashop/tree/main/lomi) — la racine de l’archive doit être `lomi/` avec `lomi.php` à l’intérieur.
+2. Zippez **uniquement** ce dossier (pas le répertoire parent).
+3. **Back office → Modules → Importer un module** → installez, puis **Activez** si besoin.
+4. **International → Localisation → Devises** — activez **EUR**, **USD** ou **XOF** selon votre boutique.
+5. **Paiement → Préférences** (ou **Moyens de paiement**) — autorisez **lomi.** pour ces devises.
+6. **Modules → lomi. → Configurer** — collez les clés secrètes et secrets webhook test / production ; copiez l’**URL webhook** dans [dashboard.lomi.africa](https://dashboard.lomi.africa) → **Développeurs → Webhooks** (au minimum **`PAYMENT_SUCCEEDED`**).
 
 Détails : [README du module PrestaShop](https://github.com/lomiafrica/prestashop/blob/main/lomi/README.md)
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/prestashop.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/prestashop.mdx
@@ -16,10 +16,12 @@ Module in the [`lomiafrica/prestashop`](https://github.com/lomiafrica/prestashop
 
 ## Install
 
-1. Zip the **`lomi`** folder from the [prestashop repository](https://github.com/lomiafrica/prestashop/tree/main/lomi).
-2. **Back office → Modules → Upload a module**.
-3. Configure **test/live secret keys**, **webhook signing secret**, and **test mode** switch.
-4. Webhook URL is displayed on the module configuration page.
+1. Open the **`lomi`** folder in [lomiafrica/prestashop](https://github.com/lomiafrica/prestashop/tree/main/lomi) — the archive root must be `lomi/` and include `lomi.php`.
+2. Zip **only** that folder (not a parent directory).
+3. **Back office → Modules → Module Manager → Upload a module** → install, then **Enable** if needed.
+4. **International → Localization → Currencies** — activate **EUR**, **USD**, or **XOF** for your shop.
+5. **Payment → Preferences** (or **Payment methods**, depending on version) — allow **lomi.** for those currencies.
+6. **Modules → lomi. → Configure** — paste test/live secret keys and webhook signing secrets; copy the **webhook URL** into [dashboard.lomi.africa](https://dashboard.lomi.africa) → **Developers → Webhooks** (subscribe to **`PAYMENT_SUCCEEDED`** at minimum).
 
 Detailed steps: [PrestaShop module README](https://github.com/lomiafrica/prestashop/blob/main/lomi/README.md)
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.fr.mdx
@@ -20,24 +20,42 @@ Source : [en-tête du plugin / readme](https://github.com/lomiafrica/woo/blob/ma
 
 ## Installation
 
-Téléchargez la dernière archive depuis les releases GitHub :
+### Release GitHub (recommandé)
 
-[Télécharger woo-lomi.zip](https://github.com/lomiafrica/lomi./releases/latest/download/woo-lomi.zip)
+Les archives officielles sont publiées sur les [releases du monorepo lomi.](https://github.com/lomiafrica/lomi./releases) lorsqu’un tag **`woo-v*`** est poussé (par ex. `woo-v1.002.0`). L’asset s’appelle toujours **`woo-lomi.zip`**.
 
-Les sources et les outils de build sont dans le [dépôt woo](https://github.com/lomiafrica/woo). Les releases pourront aussi y être publiées à terme.
+- Parcourez les [releases `woo-v*`](https://github.com/lomiafrica/lomi./releases?q=woo-v&expanded=true) et téléchargez `woo-lomi.zip`.
+- URL directe : `https://github.com/lomiafrica/lomi./releases/download/<tag>/woo-lomi.zip` (ex. `.../woo-v1.002.0/woo-lomi.zip`).
 
-1. **Extensions WordPress → Ajouter → Téléverser** : choisissez `woo-lomi.zip` et activez.
-2. Les releases sont publiées sur les tags `woo-v*` (par ex. `woo-v1.002.0`). Le nom de l’asset reste **`woo-lomi.zip`** pour garder une URL `latest/download` stable.
+S’il n’y a pas encore de release `woo-v*`, compilez depuis les sources ci-dessous ou contactez votre référent lomi.
 
-Pour compiler localement : clonez [lomiafrica/woo](https://github.com/lomiafrica/woo) puis `npm run release` (sortie dans `dist/woo-lomi-*.zip`).
+Les sources et le script de release sont dans le [dépôt woo](https://github.com/lomiafrica/woo) ; la CI produit le zip lors d’un tag `woo-v*` sur `lomiafrica/lomi.`.
+
+### Compiler depuis les sources
+
+```bash
+git clone https://github.com/lomiafrica/woo.git
+cd woo
+npm ci
+npm run release
+```
+
+Téléversez `dist/woo-lomi.zip` (ou `dist/woo-lomi-{version}.zip`).
+
+### Téléversement WordPress
+
+1. **Extensions → Ajouter → Téléverser** → choisissez `woo-lomi.zip`.
+2. **Activez** lomi. for WooCommerce.
 
 ## Liste de configuration
 
-1. Installer **lomi. WooCommerce Payment Gateway** et activer WooCommerce.
-2. Aller dans **WooCommerce → Réglages → Paiements → lomi.**.
-3. Activer la passerelle ; utiliser le **mode test** pendant l’intégration.
-4. Coller les **clés secrètes** test / production et les **secrets de signature webhook** correspondants depuis [dashboard.lomi.africa](https://dashboard.lomi.africa).
-5. Copier l’**URL webhook** affichée en rouge en haut des réglages dans le tableau de bord lomi. (**Développeur / Webhooks**), avec le même secret que dans Woo.
+1. Installer **lomi. for WooCommerce** et activer WooCommerce.
+2. Aller dans **WooCommerce → Réglages → Paiements → lomi.** (ou **Configurer**).
+3. Consulter le panneau **Setup health** (clé API, devise, secret webhook, HTTPS, mode test, `GET /me`).
+4. Activer la passerelle ; utiliser le **mode test** pendant l’intégration.
+5. Coller les **clés secrètes** test / production et les **secrets de signature webhook** depuis [dashboard.lomi.africa](https://dashboard.lomi.africa).
+6. Copier l’**URL webhook** affichée en haut des réglages dans **Tableau de bord → Webhooks** (même secret que dans Woo).
+7. Activer les événements **`PAYMENT_SUCCEEDED`** et **`REFUND_COMPLETED`**.
 
 ## Flux de paiement
 

--- a/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/woocommerce.mdx
@@ -20,16 +20,32 @@ Source: [plugin header / readme](https://github.com/lomiafrica/woo/blob/main/woo
 
 ## Install
 
-Download the latest plugin zip from GitHub Releases:
+### GitHub release (recommended)
 
-[Download woo-lomi.zip](https://github.com/lomiafrica/lomi./releases/latest/download/woo-lomi.zip)
+Official zips are published on the [lomi. monorepo releases](https://github.com/lomiafrica/lomi./releases) when maintainers push a **`woo-v*`** tag (for example `woo-v1.002.0`). The asset name is always **`woo-lomi.zip`**.
 
-Source and build tooling live in the [woo repository](https://github.com/lomiafrica/woo). Future releases may also be published from that repo.
+- Browse [releases tagged `woo-v*`](https://github.com/lomiafrica/lomi./releases?q=woo-v&expanded=true) and download `woo-lomi.zip` from the release you need.
+- Direct URL pattern: `https://github.com/lomiafrica/lomi./releases/download/<tag>/woo-lomi.zip` (example: `.../woo-v1.002.0/woo-lomi.zip`).
 
-1. **WordPress Admin → Plugins → Add New → Upload Plugin**: choose `woo-lomi.zip` and activate.
-2. Releases are published on `woo-v*` tags (for example `woo-v1.002.0`). The asset name is always **`woo-lomi.zip`** so the `latest/download` URL stays stable.
+If no `woo-v*` release is listed yet, use **build from source** below or contact your lomi. representative for a current zip.
 
-To build locally: clone [lomiafrica/woo](https://github.com/lomiafrica/woo) and run `npm run release` (output in `dist/woo-lomi-*.zip`).
+Source and release tooling live in the [woo repository](https://github.com/lomiafrica/woo); CI packages the zip from that repo when a `woo-v*` tag is pushed on `lomiafrica/lomi.`.
+
+### Build from source
+
+```bash
+git clone https://github.com/lomiafrica/woo.git
+cd woo
+npm ci
+npm run release
+```
+
+Upload `dist/woo-lomi.zip` (versioned copy: `dist/woo-lomi-{version}.zip`).
+
+### Upload in WordPress
+
+1. **Plugins → Add New → Upload Plugin** → choose `woo-lomi.zip`.
+2. **Activate** lomi. for WooCommerce.
 
 ## Setup checklist
 


### PR DESCRIPTION
## Summary

- Fix WooCommerce install docs: remove misleading `latest/download` link (resolved to CLI releases), document `woo-v*` releases on the lomi. monorepo, tag URL pattern, and build-from-source fallback via `lomiafrica/woo`.
- Fix Magento install docs: `lomi/magento2-payments` is not on Packagist — add Composer VCS repository setup and clearer manual copy steps (`app/code/Lomi/Payments/`).
- Expand PrestaShop install steps (zip layout, currencies, payment preferences, webhook dashboard setup).
- Add an install-artifact table on the e-commerce hub page (EN + FR).
