### PR TITLE
ci(plugins): run automated test suite in CI (#39)

### DIFF
--- a/.github/workflows/app-ci-plugins.yml
+++ b/.github/workflows/app-ci-plugins.yml
@@ -21,5 +21,15 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Run plugin parity checks
-        run: apps/plugins/scripts/verify-lomi-plugins.sh
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: apps/plugins/woo/pnpm-lock.yaml
+
+      - name: Run automated plugin test suite
+        run: apps/plugins/scripts/run-plugin-tests.sh

--- a/.github/workflows/app-ci-plugins.yml
+++ b/.github/workflows/app-ci-plugins.yml
@@ -18,8 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          submodules: recursive
+
+      - name: Initialize plugin submodules
+        run: |
+          git submodule update --init apps/plugins
+          git -C apps/plugins submodule update --init woo prestashop magento
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/app-ci-woo.yml
+++ b/.github/workflows/app-ci-woo.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Run plugin parity checks
-        run: apps/plugins/scripts/verify-lomi-plugins.sh
-
       - uses: pnpm/action-setup@v4
         with:
           version: 9
@@ -34,10 +31,5 @@ jobs:
           cache: pnpm
           cache-dependency-path: apps/plugins/woo/pnpm-lock.yaml
 
-      - name: Install Woo build dependencies
-        working-directory: apps/plugins/woo
-        run: pnpm install --frozen-lockfile
-
-      - name: Build Woo assets
-        working-directory: apps/plugins/woo
-        run: pnpm run build
+      - name: Run automated plugin test suite
+        run: apps/plugins/scripts/run-plugin-tests.sh

--- a/.github/workflows/app-ci-woo.yml
+++ b/.github/workflows/app-ci-woo.yml
@@ -18,8 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          submodules: recursive
+
+      - name: Initialize plugin submodules
+        run: |
+          git submodule update --init apps/plugins
+          git -C apps/plugins submodule update --init woo prestashop magento
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## Summary

- Bumps `apps/plugins` to [lomiafrica/plugins@7fc822d](https://github.com/lomiafrica/plugins/commit/7fc822d) (`run-plugin-tests.sh`, webhook contract, Bubble JSON smoke, Woo release zip validation).
- Updates `app-ci-plugins` and `app-ci-woo` to run the full suite instead of `verify-lomi-plugins.sh` only (Woo workflow no longer runs a separate `pnpm build` step).

Part of [lomiafrica/lomi.#39](https://github.com/lomiafrica/lomi./issues/39) / epic [#45](https://github.com/lomiafrica/lomi./issues/45).

**Depends on:** [lomiafrica/plugins](https://github.com/lomiafrica/plugins) PR merging `feat/automated-tests` (and ideally `docs/dev-environment` / #44 first).

## Test plan

- [ ] `app-ci-plugins` green on this PR
- [ ] `app-ci-woo` green when `apps/plugins/woo/**` changes
- [ ] Submodule resolves at `7fc822d` with `submodules: recursive`