### PR TITLE
fix(webhooks): timing-safe comparison on Wave legacy Bearer auth

### DIFF
--- a/apps/api/src/webhooks/providers/wave/wave-webhook.service.ts
+++ b/apps/api/src/webhooks/providers/wave/wave-webhook.service.ts
@@ -226,11 +226,12 @@ export class WaveWebhookService {
         providedSecret = parts[1];
       }
 
-      this.logger.debug(
-        `Authorization check with secret ending in: ${providedSecret.slice(-4)}`,
-      );
-
-      return providedSecret === this.webhookSecret;
+      const providedBuffer = Buffer.from(providedSecret);
+      const expectedBuffer = Buffer.from(this.webhookSecret);
+      if (providedBuffer.length !== expectedBuffer.length) {
+        return false;
+      }
+      return crypto.timingSafeEqual(providedBuffer, expectedBuffer);
     } catch (error) {
       this.logger.error('Error verifying Authorization header:', error);
       return process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
## Summary

Salvages the one behavior-neutral security improvement from the closed PR #46 without any of its regressive changes.

- Replaces the plain `===` secret comparison on the legacy Wave `Authorization: Bearer <secret>` path with `crypto.timingSafeEqual` (constant-time), removing a timing side-channel that could leak the webhook secret.
- Removes the debug log that printed the secret's last 4 characters.

## Not included (intentionally)

The non-production `NODE_ENV !== 'production'` fallbacks in this handler are **kept**, so sandbox/staging deployments never reject Wave webhooks. This was the explicit reason #46 was closed.

## Behavior

Identical: a matching secret returns `true`, a mismatch returns `false`. Only the comparison method (and the secret-leaking log) changed.

Made with [Cursor](https://cursor.com)