### PR TITLE
fix(ci): unblock openapi export and doctool checkout

### DIFF
--- a/.github/workflows/app-ci-doctool.yml
+++ b/.github/workflows/app-ci-doctool.yml
@@ -26,10 +26,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
       - uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "22"
           cache: pnpm
           cache-dependency-path: apps/docs/pnpm-lock.yaml
       - name: Build doctool (dt)

--- a/.github/workflows/app-ci-doctool.yml
+++ b/.github/workflows/app-ci-doctool.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with:
-          submodules: recursive
       - uses: actions/checkout@v5
         with:
           repository: lomiafrica/doctool

--- a/apps/api/src/core/gim/gim.module.ts
+++ b/apps/api/src/core/gim/gim.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { SupabaseModule } from '../../utils/supabase/supabase.module';
-import { WebhooksModule } from '../../webhooks/webhooks.module';
+import { WebhookSenderModule } from '../../webhooks/webhook-sender.module';
 import { RadarModule } from '../radar/radar.module';
 import { GimHmacService } from './gim-hmac.service';
 import { GimClientService } from './gim-client.service';
@@ -9,7 +9,7 @@ import { GimCheckoutService } from './gim-checkout.service';
 import { GimReturnController } from './gim-return.controller';
 
 @Module({
-  imports: [SupabaseModule, RadarModule, WebhooksModule],
+  imports: [SupabaseModule, RadarModule, WebhookSenderModule],
   controllers: [GimReturnController],
   providers: [
     GimHmacService,

--- a/apps/api/src/webhooks/webhook-sender.module.ts
+++ b/apps/api/src/webhooks/webhook-sender.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { SupabaseModule } from '../utils/supabase/supabase.module';
+import { CliModule } from '../cli/cli.module';
+import { WebhookSenderService } from './webhook-sender.service';
+
+/** Webhook dispatch without BullMQ listeners or provider ingress. */
+@Module({
+  imports: [SupabaseModule, CliModule],
+  providers: [WebhookSenderService],
+  exports: [WebhookSenderService],
+})
+export class WebhookSenderModule {}

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -3,7 +3,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { WebhooksController } from './webhooks.controller';
 import { WebhooksInternalController } from './webhooks-internal.controller';
 import { WebhooksService } from './webhooks.service';
-import { WebhookSenderService } from './webhook-sender.service';
+import { WebhookSenderModule } from './webhook-sender.module';
 import { WebhookListener } from './listeners/webhook.listener';
 import { WebhookQueueProcessor } from './processors/webhook.processor';
 import { WaveWebhookModule } from './providers/wave/wave-webhook.module';
@@ -28,16 +28,16 @@ import { InternalCronGuard } from '../core/common/guards/internal-cron.guard';
     StripeWebhookModule,
     MtnWebhookModule,
     SpiWebhookModule,
+    WebhookSenderModule,
     CliModule,
   ],
   controllers: [WebhooksController, WebhooksInternalController],
   providers: [
     WebhooksService,
-    WebhookSenderService,
     WebhookListener,
     WebhookQueueProcessor,
     InternalCronGuard,
   ],
-  exports: [WebhookSenderService],
+  exports: [WebhookSenderModule],
 })
 export class WebhooksModule {}

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -2617,26 +2617,7 @@
                     "type": "boolean"
                   },
                   "require_billing_address": {
-                    "type": "boolean",
-                    "description": "When true, show and require billing address on checkout."
-                  },
-                  "require_email": {
-                    "type": "boolean",
-                    "description": "When true, show and require customer email. Default true when unset.",
-                    "default": true
-                  },
-                  "require_phone": {
-                    "type": "boolean",
-                    "description": "When true, show and require customer phone. Default false when unset.",
-                    "default": false
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Optional ordered checkout field schema. When provided, overrides require_* booleans.",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": true
-                    }
+                    "type": "boolean"
                   },
                   "payment_link_id": {
                     "type": "string",
@@ -2893,26 +2874,7 @@
                     "type": "boolean"
                   },
                   "require_billing_address": {
-                    "type": "boolean",
-                    "description": "When true, show and require billing address on checkout."
-                  },
-                  "require_email": {
-                    "type": "boolean",
-                    "description": "When true, show and require customer email. Default true when unset.",
-                    "default": true
-                  },
-                  "require_phone": {
-                    "type": "boolean",
-                    "description": "When true, show and require customer phone. Default false when unset.",
-                    "default": false
-                  },
-                  "fields": {
-                    "type": "array",
-                    "description": "Optional ordered checkout field schema. When provided, overrides require_* booleans.",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": true
-                    }
+                    "type": "boolean"
                   },
                   "expires_at": {
                     "type": "string",
@@ -4092,6 +4054,55 @@
           }
         ],
         "summary": "Create MTN MoMo charge",
+        "tags": [
+          "Advanced Direct Charges"
+        ]
+      }
+    },
+    "/charge/gim": {
+      "post": {
+        "description": "Charges a card via GIM Pay PayByCard. May return a redirect URL for 3DS or signal retry_other_rail for Stripe fallback.",
+        "operationId": "ChargesController_createGimCharge",
+        "parameters": [
+          {
+            "name": "Lomi-Account",
+            "in": "header",
+            "description": "Optional lomi. Network account id (`acct_...`). When present, the API key acts as the Operator and the request targets the connected Member Account.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "acct_1234567890"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGimChargeDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "GIM charge created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GimChargeResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api-key": []
+          }
+        ],
+        "summary": "Create GIM Pay card charge (direct PayByCard)",
         "tags": [
           "Advanced Direct Charges"
         ]
@@ -7344,6 +7355,126 @@
         "required": [
           "success",
           "data"
+        ]
+      },
+      "CreateGimChargeDto": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number",
+            "example": 10000,
+            "description": "Amount in XOF francs"
+          },
+          "currency_code": {
+            "type": "string",
+            "example": "XOF",
+            "enum": [
+              "XOF"
+            ]
+          },
+          "pan": {
+            "type": "string",
+            "example": "4221941234569109"
+          },
+          "expiry": {
+            "type": "string",
+            "example": "06/25",
+            "description": "MM/YY or YYMM"
+          },
+          "cvv": {
+            "type": "string",
+            "example": "123"
+          },
+          "customer_id": {
+            "type": "string",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "customer_email": {
+            "type": "string",
+            "example": "john@example.com"
+          },
+          "customer_name": {
+            "type": "string",
+            "example": "John Doe"
+          },
+          "customer_phone": {
+            "type": "string",
+            "example": "+221771234567"
+          },
+          "description": {
+            "type": "string"
+          },
+          "payment_reference": {
+            "type": "string"
+          },
+          "product_id": {
+            "type": "string"
+          },
+          "subscription_id": {
+            "type": "string"
+          },
+          "checkout_session_id": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "number",
+            "default": 1
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "ecom_ip": {
+            "type": "string",
+            "description": "Customer IP for EComIp"
+          }
+        },
+        "required": [
+          "amount",
+          "pan",
+          "expiry",
+          "cvv"
+        ]
+      },
+      "GimChargeResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "approved",
+              "declined",
+              "redirect_3ds",
+              "retry_other_rail"
+            ]
+          },
+          "system_reference": {
+            "type": "number"
+          },
+          "merchant_reference": {
+            "type": "string"
+          },
+          "action_code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "auth_code": {
+            "type": "string"
+          },
+          "transaction_id": {
+            "type": "string"
+          },
+          "next_action": {
+            "$ref": "#/components/schemas/ChargeNextActionDto"
+          }
+        },
+        "required": [
+          "success"
         ]
       },
       "CreateCardChargeDto": {


### PR DESCRIPTION
## Summary

Fixes the two pre-existing CI failures called out after the PR merge sweep:

- **build-api / `openapi:export`**: `GimModule` imported the full `WebhooksModule`, which pulled `WebhookListener` + BullMQ into the OpenAPI export graph (no `BullModule.forRoot`). Split `WebhookSenderService` into a lightweight `WebhookSenderModule` used by `GimModule` instead.
- **build-doctool**: Removed `submodules: recursive` from checkout — this workflow only needs the monorepo root and a separate `doctool` checkout, not private submodules.

Also regenerates `apps/docs/openapi.json` now that export succeeds again.

## Behavior

No runtime API or webhook behavior changes — module wiring only for OpenAPI bootstrap and CI checkout.

Made with [Cursor](https://cursor.com)