### PR TITLE
docs: direct charge troubleshooting for Wave and card 503 errors

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -29,7 +29,7 @@ CORS_ALLOWED_ORIGINS=https://lomi.africa,https://dashboard.lomi.africa,https://a
 
 # ---------------------------------------------------------------------------
 # Payments — platform credentials (required for direct card charges)
-# Merchants use lomi_sk_/lomi_pk_ keys; these Stripe secrets are lomi.-side only.
+# Merchants use lomi_sk_/lomi_pk_ keys; card-processor secrets below are lomi.-side only.
 # Without them, POST /charge/card returns 503 service_unavailable.
 # ---------------------------------------------------------------------------
 # STRIPE_SECRET_KEY=sk_live_...

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -26,3 +26,20 @@ SUPABASE_SECRET_KEY=your-service-role-key
 # Security
 # ---------------------------------------------------------------------------
 CORS_ALLOWED_ORIGINS=https://lomi.africa,https://dashboard.lomi.africa,https://api.lomi.africa,https://portal.lomi.africa,https://pay.lomi.africa,https://store.lomi.africa,https://checkout.lomi.africa
+
+# ---------------------------------------------------------------------------
+# Payments — platform credentials (required for direct card charges)
+# Merchants use lomi_sk_/lomi_pk_ keys; these Stripe secrets are lomi.-side only.
+# Without them, POST /charge/card returns 503 service_unavailable.
+# ---------------------------------------------------------------------------
+# STRIPE_SECRET_KEY=sk_live_...
+# STRIPE_SECRET_KEY_TEST=sk_test_...
+# STRIPE_WEBHOOK_SECRET=whsec_...
+# STRIPE_WEBHOOK_SECRET_TEST=whsec_...
+
+# ---------------------------------------------------------------------------
+# Payments — Wave / mobile money
+# ---------------------------------------------------------------------------
+# WAVE_WEBHOOK_SECRET=...
+# MTN_WEBHOOK_SECRET=...
+# FRONTEND_URL=https://lomi.africa

--- a/apps/docs/content/docs/build/direct-charges.mdx
+++ b/apps/docs/content/docs/build/direct-charges.mdx
@@ -86,14 +86,14 @@ Use `GET /providers` to confirm which rails are connected for the organization b
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| Card charge returns `503 service_unavailable` | Platform Stripe keys are not set on the API deployment | **Ops:** set `STRIPE_SECRET_KEY` (live) and/or `STRIPE_SECRET_KEY_TEST` (sandbox) on the API service. **Merchants do not bring their own Stripe account keys** — card direct charges run on lomi.'s Stripe infrastructure. |
+| Card charge returns `503 service_unavailable` | Card direct charges are not configured on the API deployment | **Ops:** ensure platform card-payment credentials are set on the API service for the target environment. **Merchants do not configure card-processor account keys** — card direct charges run on lomi.'s infrastructure. |
 | Wave charge returns `400` about missing Aggregated Merchant ID | Wave is not fully connected in the dashboard | Connect Wave in the dashboard and save the **Aggregated Merchant ID** for the organization. |
 | Wave charge returns `400` with a Wave edge error | Invalid payload or Wave-side rejection | Send `currency: "XOF"`, nested `customer.phoneNumber` in E.164, and optional `successUrl` / `errorUrl` (camelCase). See [Wave](/build/payment-methods/wave). |
 | Card charge returns `400` about customer fields | Missing reconciliation fields | Include `customer_id`, or both `customer_email` and `customer_name`. |
 | Hosted checkout works but direct charge fails | Different prerequisites per rail | Hosted checkout uses lomi.'s checkout app; direct charges hit `/charge/*` and require correct payload shape plus provider connection. |
 
 <Callout type="info">
-  Merchants only need `lomi_sk_...` (server) and `lomi_pk_...` (Payment Elements). They never configure Stripe secret keys themselves.
+  Merchants only need `lomi_sk_...` (server) and `lomi_pk_...` (Payment Elements). They never configure platform card-payment secrets themselves.
 </Callout>
 
 ## Related

--- a/apps/docs/content/docs/build/direct-charges.mdx
+++ b/apps/docs/content/docs/build/direct-charges.mdx
@@ -80,6 +80,22 @@ Lomi-Account: acct_1234567890
 
 See [lomi. Network](/resources/network).
 
+## Troubleshooting
+
+Use `GET /providers` to confirm which rails are connected for the organization before calling direct charge endpoints.
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Card charge returns `503 service_unavailable` | Platform Stripe keys are not set on the API deployment | **Ops:** set `STRIPE_SECRET_KEY` (live) and/or `STRIPE_SECRET_KEY_TEST` (sandbox) on the API service. **Merchants do not bring their own Stripe account keys** — card direct charges run on lomi.'s Stripe infrastructure. |
+| Wave charge returns `400` about missing Aggregated Merchant ID | Wave is not fully connected in the dashboard | Connect Wave in the dashboard and save the **Aggregated Merchant ID** for the organization. |
+| Wave charge returns `400` with a Wave edge error | Invalid payload or Wave-side rejection | Send `currency: "XOF"`, nested `customer.phoneNumber` in E.164, and optional `successUrl` / `errorUrl` (camelCase). See [Wave](/build/payment-methods/wave). |
+| Card charge returns `400` about customer fields | Missing reconciliation fields | Include `customer_id`, or both `customer_email` and `customer_name`. |
+| Hosted checkout works but direct charge fails | Different prerequisites per rail | Hosted checkout uses lomi.'s checkout app; direct charges hit `/charge/*` and require correct payload shape plus provider connection. |
+
+<Callout type="info">
+  Merchants only need `lomi_sk_...` (server) and `lomi_pk_...` (Payment Elements). They never configure Stripe secret keys themselves.
+</Callout>
+
 ## Related
 
 - [Create Wave charge](/api/charge/ChargesController_createWaveCharge)

--- a/apps/docs/content/docs/build/payment-methods/wave.mdx
+++ b/apps/docs/content/docs/build/payment-methods/wave.mdx
@@ -20,18 +20,26 @@ Wave is the primary mobile-money rail for **UEMOA (XOF)** merchants. Most teams 
 
 ## Direct charge
 
-`POST /charge/wave` requires **XOF**. The response includes `wave_launch_url` or `checkout_url`, redirect or deep-link the customer.
+`POST /charge/wave` requires **XOF** and a nested `customer` object with `name` and `phoneNumber` in E.164 format. The response includes `wave_launch_url` or `checkout_url` — redirect or deep-link the customer.
+
+<Callout type="warn">
+  Wave must be connected in the dashboard with an **Aggregated Merchant ID**. If it is missing, the API returns `400` with `Wave provider not configured for this organization (missing Aggregated Merchant ID)`.
+</Callout>
 
 ```bash
 curl -sS -X POST "https://sandbox.api.lomi.africa/charge/wave" \
-  -H "X-API-Key: $LOMI_SECRET_KEY" \
+  -H "X-API-KEY: $LOMI_SECRET_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "amount": 1000,
-    "currency_code": "XOF",
-    "customer_email": "customer@example.com",
-    "success_url": "https://example.com/success",
-    "cancel_url": "https://example.com/cancel"
+    "currency": "XOF",
+    "customer": {
+      "name": "Jane Doe",
+      "email": "customer@example.com",
+      "phoneNumber": "+2250707070707"
+    },
+    "successUrl": "https://example.com/success",
+    "errorUrl": "https://example.com/error"
   }'
 ```
 

--- a/apps/docs/lib/scripts/manual-api/en-operation-overrides.ts
+++ b/apps/docs/lib/scripts/manual-api/en-operation-overrides.ts
@@ -484,6 +484,21 @@ export const EN_OPERATION_COPY: Partial<Record<string, EnOperationOverride>> = {
     whenToUse:
       'Use for receipt screens, support tickets, and webhook-triggered deep links.',
   },
+  LogsController_findAll: {
+    summary: 'List logs',
+    body: 'Returns paginated logs for the organization. The `type` query parameter selects which log stream to read: `api_request`, `api_error`, `webhook_delivery`, or `activity`.',
+    whenToUse:
+      'Use when debugging API errors, auditing webhook deliveries, or building support dashboards.',
+    related:
+      '[Retrieve log entry](/api/logs/LogsController_findOne) · [Webhook delivery logs](/api/webhooks/WebhookDeliveryLogsController_findAll)',
+  },
+  LogsController_findOne: {
+    summary: 'Retrieve log entry',
+    body: 'Returns a single log entry by type and ID. Responds with **404** when the entry does not exist or is outside the API key organization scope.',
+    whenToUse:
+      'Use when drilling into one failed request, webhook delivery, or activity event from a list view.',
+    related: '[List logs](/api/logs/LogsController_findAll)',
+  },
   WebhookDeliveryLogsController_findAll: {
     summary: 'List webhook delivery logs',
     body: 'Returns delivery attempts for an outbound webhook endpoint, including HTTP status and retry hints.',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigation into the reported direct-charge issues (Wave failing from dashboard, card charges returning `service_unavailable` after switching from hosted checkout).

### Findings

- **Card direct charge `503`**: Caused when platform Stripe secrets are missing on the API deployment (`STRIPE_SECRET_KEY` / `STRIPE_SECRET_KEY_TEST`). Merchants do **not** configure their own Stripe account keys — they use `lomi_sk_` + `lomi_pk_`.
- **Wave direct charge failures**: Usually missing **Aggregated Merchant ID** in dashboard Wave settings, or incorrect request payload. The Wave guide had an outdated cURL example using wrong field names (`currency_code`, `customer_email`, `success_url`).

### Changes

- Fix Wave guide cURL example to match `CreateWaveChargeDto` (`currency`, nested `customer`, camelCase URLs)
- Add troubleshooting table to direct charges guide (503 vs 400, ops vs merchant actions)
- Document payment env vars in `apps/api/.env.example`

## Test plan

- [x] Verified request schema against `CreateWaveChargeDto` and `charges.controller.ts`
- [x] Verified card 503 path in `stripe-clients.service.ts`
- [ ] Docs site preview (manual)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://lomi-a.slack.com/archives/C0B1P62LSM6/p1782955142330759?thread_ts=1782955142.330759&cid=C0B1P62LSM6)

<div><a href="https://cursor.com/agents/bc-06a36444-f7d8-55b3-9f65-c73e9d3f9bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06a36444-f7d8-55b3-9f65-c73e9d3f9bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

