### PR TITLE
Chore/bump plugins submodule

### DIFF
--- a/apps/plugins/E2E.md
+++ b/apps/plugins/E2E.md
@@ -1,115 +1,215 @@
-# Plugin E2E smoke matrix
+# Manual E2E smoke tests (lomi. plugins)
 
-Manual checklist per platform. Run in **test mode** first, then repeat critical paths in **live mode** with small amounts.
+Parent epic: [lomi. #45](https://github.com/lomiafrica/lomi./issues/45).
 
-## Shared expectations
+Use this checklist after plugin changes or before a release. Pair with:
 
-| Step | Expected |
-|------|----------|
-| Create checkout session | `integration_source` matches platform enum |
-| XOF store | Amount sent in whole francs (not ×100) |
-| Hosted checkout pay | Order marked paid / completed |
-| Webhook `PAYMENT_SUCCEEDED` | HMAC verified; order completes if return URL missed |
-| Test/live toggle | API base + webhook secret switch together |
-| Abandon | Back from hosted checkout restores cart / pending order |
+- [DEV-ENV.md](./DEV-ENV.md) — local stacks, tunnels, sandbox keys
+- `./scripts/run-plugin-tests.sh` — automated static + webhook contract checks (CI runs the same)
 
-Automated suite: `./scripts/run-plugin-tests.sh` (static parity + webhook contract + Woo zip). Static-only: `./scripts/run-plugin-tests.sh --fast`
+**Credentials:** lomi. **sandbox** org only. Never commit API keys or `whsec_…` secrets.
+
+---
+
+## Pre-flight (all platforms)
+
+| Step | Pass criteria |
+|------|----------------|
+| Sandbox keys | Test secret key (`lomi_sk_test_…`) + test webhook signing secret (`whsec_…`) from [dashboard.lomi.africa](https://dashboard.lomi.africa) |
+| Test mode ON | Plugin uses `https://sandbox.api.lomi.africa` |
+| Public HTTPS | Cloudflare Tunnel or ngrok exposes your local shop (webhooks require a reachable URL) |
+| Store URL | WordPress / PrestaShop / Magento **base URL** matches the tunnel hostname (not `localhost`) when testing redirects |
+| Webhook endpoint | Registered in dashboard → **Developers → Webhooks** with events **`PAYMENT_SUCCEEDED`** (+ **`REFUND_COMPLETED`** on Woo) |
+| Test webhook | Dashboard “Send test webhook” → **HTTP 200** (no order created — expected) |
+| Currency | Shop currency **XOF**, **USD**, or **EUR** |
+
+**Test card (sandbox):** `4242 4242 4242 4242` — any future expiry, any CVC. More: [Sandbox payments](https://docs.lomi.africa/start/sandbox-payments).
 
 ---
 
 ## WooCommerce
 
-**Environment:** Docker Compose ([`dev/woocommerce`](./dev/woocommerce)) + **Cloudflare Tunnel** for HTTPS webhooks, or shared staging. See [DEV-ENV.md](./DEV-ENV.md).
+**Stack:** [dev/woocommerce/docker-compose.yml](./dev/woocommerce/docker-compose.yml) (bind-mount `woo/` → `woo-lomi`).
+
+### Setup
 
 ```bash
-cd dev/woocommerce && docker compose up -d
-# cloudflared tunnel --url http://localhost:8080
-```
-
-1. Install WooCommerce; activate `woo-lomi` (bind-mounted from `woo/` submodule).
-2. Configure test API key + test webhook secret; enable test mode.
-3. Set WordPress site URL to tunnel hostname when testing checkout return + webhooks.
-4. Place order → redirect to lomi. checkout → pay (sandbox).
-5. Confirm order `processing`/`completed` and webhook note.
-6. Toggle live keys (staging only if available); confirm `api.lomi.africa` used.
-7. Start checkout, use browser Back → cart restored (abandon JS).
-
----
-
-## Magento
-
-**Environment:** [`magento/dev`](magento/dev) Docker + ngrok for webhooks.
-
-```bash
-cd apps/plugins/magento/dev
+cd dev/woocommerce
 docker compose up -d
-# expose https URL for webhook endpoint
 ```
 
-1. `bin/magento` → enable Lomi, test mode, paste test keys.
-2. Place order → hosted checkout → pay.
-3. Webhook `PAYMENT_SUCCEEDED` → invoice paid.
-4. Admin **Setup health** shows GET `/me` OK.
-5. Abandon: back button on checkout → quote restored.
-6. (Optional) Refund in dashboard → `REFUND_COMPLETED` webhook adds order comment.
+1. Finish WordPress install → http://localhost:8080
+2. Install and activate **WooCommerce** (9.6+)
+3. Activate **lomi. for WooCommerce**
+4. Start tunnel: `cloudflared tunnel --url http://localhost:8080`
+5. **Settings → General** — set **Site Address (URL)** to the tunnel HTTPS URL
+6. **WooCommerce → Settings → Payments → lomi.** — enable gateway, **test mode**, paste test secret key + test webhook secret
+7. Copy **Webhook URL** from the settings page → dashboard webhook (events above)
+8. **Setup health** panel — API connection **OK**, webhook secret **Configured**
 
-Optional runtime verify:
+### Checkout branding (#40)
+
+| Check | Pass criteria |
+|-------|----------------|
+| Classic checkout | Payment row shows **branding card**: pay-with image, method icons (right), lock hint |
+| Blocks checkout | Same card in Woo Blocks payment method (rebuild `blocks.js` after JS changes) |
+| No duplicate title | Default “lomi.” title hidden when branding card is active |
+| Responsive | Card spans full payment row width; icons do not overflow on mobile |
+
+### Payment flow
+
+| # | Action | Expected |
+|---|--------|----------|
+| 1 | Add product → checkout → pay with **lomi.** | Redirect to `checkout.lomi.africa` (sandbox) |
+| 2 | Pay with test card | Success page on lomi. checkout |
+| 3 | Return to store | Order **Processing** / **Completed** (per Woo settings) |
+| 4 | Dashboard webhook log | `PAYMENT_SUCCEEDED` → **200** |
+| 5 | Woo order notes / status | Payment captured; no stuck **Pending payment** |
+
+### Admin UX (#40)
+
+| Check | Pass criteria |
+|-------|----------------|
+| Copy webhook URL | **Copy URL** button copies full HTTPS webhook URL |
+| Webhook events row | **Checklist** (not permanent Warning) |
+| API error | Invalid key shows merchant-friendly message (not raw JSON) |
+| Advanced settings | Hidden by default; toggle reveals public keys / extra fields |
+
+### Automated (no Docker)
 
 ```bash
-./scripts/verify-lomi-plugins.sh --run-runtime --magento-root /path/to/magento
+./scripts/run-plugin-tests.sh --fast   # static only
+./scripts/run-plugin-tests.sh          # includes Woo zip build
 ```
 
 ---
 
 ## PrestaShop
 
-**Environment:** PrestaShop docker-compose in plugin repo (if present) or staging shop.
+**Stack:** [prestashop/docker-compose.yml](./prestashop/docker-compose.yml) (module baked into image from `prestashop/lomi/`).
 
-1. Configure `LOMI_MODE=1` (test), test API key + webhook secret.
-2. Checkout → Pay with lomi. → hosted checkout → pay.
-3. Webhook completes order if callback delayed.
-4. Cancel on hosted checkout → returns to checkout step 3.
-5. Abandon: browser back → session cleared, cart intact.
-
----
-
-## Shopify
-
-**Environment:** CI (`shopify-ci.yml`) + staging shop with app installed.
-
-1. Cart checkout → draft order → lomi. session (`integration_source: shopify`).
-2. Pay in hosted checkout → order marked paid in Shopify admin.
-3. Confirm recent transactions in app admin (when scoped by integration).
-
----
-
-## Bubble
-
-**Environment:** Bubble app (version-test) + lomi. sandbox keys.
-
-1. Plugins → lomi. → paste test API secret + webhook secret (Development).
-2. Workflow: **Create checkout session** (with `bubble_thing_id`) → **Mark checkout redirect** → **Redirect to checkout** (or **lomi. Pay button**).
-3. Pay in hosted sandbox checkout → land on `success_url` with `session_id`.
-4. Success page: **Complete if paid** → if `paid`, mark Thing paid; else **Abandon checkout**.
-5. Webhook API workflow: **Verify and parse webhook** → **On payment succeeded** → update Thing (idempotent).
-6. Abandon: start checkout → browser Back → `lomi:checkout-abandon` / unpaid Thing.
-7. Refund: webhook branch **On refund completed** → update Thing / note.
-8. Confirm dashboard shows `integration_source: bubble`.
-
-Local helpers:
+### Setup
 
 ```bash
-LOMI_SECRET_KEY=lomi_sk_test_... node apps/plugins/bubble/scripts/smoke-test.mjs
-apps/plugins/scripts/verify-lomi-plugins.sh
+cd prestashop
+cp local.env.sample local.env   # edit DB passwords if needed
+docker compose up -d --build
+```
+
+1. Complete PrestaShop installer → http://localhost:8000
+2. Enable currency **EUR** / **USD** / **XOF**; configure a **shipping carrier**
+3. **Modules → lomi.** → Configure — test mode, keys, webhook secret
+4. Tunnel HTTPS → update shop URL in **Shop parameters → Traffic & SEO** (or hosts file + tunnel)
+5. Register webhook URL from module config in dashboard
+
+### Checkout branding (#40)
+
+| Check | Pass criteria |
+|-------|----------------|
+| Payment step | **lomi.** option shows branding card (same BEM classes as Woo) |
+| Selection state | Selected payment option highlights border; radio + card aligned |
+| CTA | Redirect to hosted checkout after confirming payment method |
+
+### Payment flow
+
+| # | Action | Expected |
+|---|--------|----------|
+| 1 | Cart → checkout (address + carrier) → **lomi.** | Redirect to sandbox checkout |
+| 2 | Pay with test card | Return to shop and/or webhook fires |
+| 3 | Order status | **Paid via lomi.** |
+| 4 | Webhook | `PAYMENT_SUCCEEDED` → **200** |
+
+**Logs:** Advanced parameters → Logs — filter `lomi`.
+
+---
+
+## Magento 2
+
+**Stack:** [magento/dev](./magento/dev) (Docker, ~3 min first boot).
+
+### Setup
+
+```bash
+cd magento/dev
+cp .env.example .env   # LOMI_TEST_SK, LOMI_TEST_WEBHOOK_SECRET
+docker compose up -d --build
+bash setup.sh
+```
+
+1. Storefront http://localhost:8080 — admin `admin` / `Admin12345!`
+2. Tunnel → set `web/unsecure/base_url` and `web/secure/base_url` to tunnel HTTPS URL
+3. **Stores → Configuration → Sales → Payment Methods → lomi.** — test mode + secrets
+4. Dashboard webhook: `https://YOUR-TUNNEL/lomi/payment/webhook` — `PAYMENT_SUCCEEDED`
+
+```bash
+docker compose exec --user www-data magento php app/code/Lomi/Payments/dev/check-webhook-config.php
+```
+
+### Checkout branding (#40)
+
+| Check | Pass criteria |
+|-------|----------------|
+| Payment method list | Branding card with pay-with image, wide Apple/Google Pay icons, lock hint |
+| Title fallback | Empty title → branding card; non-empty title → legacy text label |
+| Static assets | `setup:static-content:deploy` run if images missing |
+
+### Payment flow
+
+| # | Action | Expected |
+|---|--------|----------|
+| 1 | Checkout → **lomi.** → Place order | Redirect to sandbox checkout |
+| 2 | Pay with test card | Order **Processing** |
+| 3 | Webhook | `PAYMENT_SUCCEEDED` → **200** `success` |
+| 4 | Callback | `/lomi/payment/callback` reachable if customer returns |
+
+Optional CLI: `dev/verify-order-session.php --apply` after a test order.
+
+---
+
+## Cross-platform parity (#40)
+
+Run once per release that touches checkout UI:
+
+| Element | Woo | PrestaShop | Magento |
+|---------|-----|------------|---------|
+| Root class `.wc-lomi-checkout-branding` | ✓ | ✓ | ✓ |
+| `__main` / `__brand` / `__methods` layout | ✓ | ✓ | ✓ |
+| Pay-with image | ✓ | ✓ | ✓ |
+| Method icons (card, mobile money, Apple/Google wide) | ✓ | ✓ | ✓ |
+| Lock hint “Secure hosted checkout…” | ✓ | ✓ | ✓ |
+
+```bash
+./scripts/verify-lomi-plugins.sh
 ```
 
 ---
 
-## Release tags
+## Bubble (smoke only)
 
-| Platform | Tag pattern | Workflow |
-|----------|-------------|----------|
-| Woo | `woo-v*` | `woo-release.yml` |
-| Magento | `magento-v*` | `magento-release.yml` |
-| PrestaShop | `prestashop-v*` | `prestashop-release.yml` |
-| Bubble | `bubble-v*` | `bubble-release.yml` |
+Submodule may be private. When available:
+
+```bash
+node scripts/test_bubble_json.mjs
+```
+
+Manual: create session action → sandbox checkout → `LOM-parse_webhook` receives `PAYMENT_SUCCEEDED`. See submodule README.
+
+---
+
+## Sign-off template
+
+Copy into PR or release notes:
+
+```
+Platform: Woo / PrestaShop / Magento
+Commit: <submodule SHA>
+Tunnel URL: <ephemeral — do not commit>
+Date:
+
+[ ] Pre-flight checklist
+[ ] Branding card on checkout
+[ ] Sandbox payment 4242…
+[ ] PAYMENT_SUCCEEDED webhook 200
+[ ] Order status correct
+[ ] run-plugin-tests.sh green
+```

--- a/apps/plugins/scripts/verify-lomi-plugins.sh
+++ b/apps/plugins/scripts/verify-lomi-plugins.sh
@@ -148,18 +148,21 @@ echo "PASS: No legacy brand references found."
 
 log "2/8 Validating Lomi API contract references in plugins"
 
+# Woo sends X-API-KEY and reads HTTP_X_LOMI_SIGNATURE / HTTP_X_LOMI_EVENT ($_SERVER keys).
+LOMI_API_CONTRACT_RE='checkout-sessions|X-API-[Kk]ey|X-Lomi-Signature|HTTP_X_LOMI_SIGNATURE|X-Lomi-Event|HTTP_X_LOMI_EVENT|api\.lomi\.africa|sandbox\.api\.lomi\.africa'
+
 echo "- Magento"
-search_must_exist "POST.*checkout-sessions|/checkout-sessions|X-API-Key|X-Lomi-Signature|X-Lomi-Event|api\.lomi\.africa|sandbox\.api\.lomi\.africa" \
+search_must_exist "$LOMI_API_CONTRACT_RE" \
   "$PLUGINS_DIR/magento"
 echo "  PASS"
 
 echo "- PrestaShop"
-search_must_exist "/checkout-sessions|X-API-Key|X-Lomi-Signature|X-Lomi-Event|api\.lomi\.africa|sandbox\.api\.lomi\.africa" \
+search_must_exist "$LOMI_API_CONTRACT_RE" \
   "$PLUGINS_DIR/prestashop"
 echo "  PASS"
 
 echo "- Woo"
-search_must_exist "/checkout-sessions|X-API-Key|X-Lomi-Signature|X-Lomi-Event|api\.lomi\.africa|sandbox\.api\.lomi\.africa" \
+search_must_exist "$LOMI_API_CONTRACT_RE" \
   "$PLUGINS_DIR/woo"
 echo "  PASS"
 
@@ -174,7 +177,7 @@ fi
 
 echo "- Bubble"
 if plugin_present "$PLUGINS_DIR/bubble"; then
-  search_must_exist "/checkout-sessions|X-API-Key|X-Lomi-Signature|api\.lomi\.africa|sandbox\.api\.lomi\.africa" \
+  search_must_exist "$LOMI_API_CONTRACT_RE" \
     "$PLUGINS_DIR/bubble"
   echo "  PASS"
 else


### PR DESCRIPTION
## Summary

Updates the `apps/plugins` submodule to [`bd3840b`](https://github.com/lomiafrica/plugins/commit/bd3840b) on `lomiafrica/plugins`, picking up:

- **Submodule refs** for Woo, PrestaShop, and Magento at the merged **#40** checkout branding + Woo merchant setup UX (`225baed`, `cb0b4e2`, `d7d615d`)
- **`E2E.md`** — manual smoke checklist (Woo / PrestaShop / Magento, tunnel + sandbox)
- **CI fix** — `verify-lomi-plugins.sh` accepts Woo `X-API-KEY` and `HTTP_X_LOMI_*` webhook headers

## Validation

- [x] `./scripts/run-plugin-tests.sh --fast` green on `apps/plugins`
- [x] Woo sandbox E2E: Docker + Cloudflare tunnel + `PAYMENT_SUCCEEDED` webhook + test card `4242…`

## Submodule delta

| Pointer | Commit |
|---------|--------|
| Before (`main`) | `312557d` |
| After | `bd3840b` |

## Test plan

- [x] CI `app-ci-plugins` / `app-ci-woo` green
- [ ] `git submodule update --init apps/plugins` on a fresh clone resolves cleanly