### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **lomi.** payment-platform monorepo. There is **no root `package.json`/Makefile**; each app under `apps/` is installed and run independently. Only the open-source apps are checked out here (`apps/api`, `apps/cli`, `apps/docs`, `apps/mcp`, `apps/sdks`, `apps/plugins`). The other `apps/*` entries in `.gitmodules` (e.g. `dashboard`, `checkout`, `storefront`, `admin`) are **private submodules that are not initialized** in this environment.
+
+Standard per-app commands live in each app's `package.json`/`README.md` and in `.github/workflows/`; the notes below only cover non-obvious setup/run caveats.
+
+### Toolchain (already provisioned in the VM snapshot)
+- Node 22 + pnpm 10, Go 1.22.
+- **Rust ≥ 1.85 is required** (the CLI uses edition 2024). The VM's default base image ships Rust 1.83, which fails to compile `apps/cli`. The snapshot has been updated to the latest stable via `rustup update stable`; if a future VM reverts to 1.83, run `rustup update stable` before building the CLI.
+- **Redis** is installed for the API's BullMQ queues. It is **not auto-started** — run `redis-server --daemonize yes --save "" --appendonly no` once per boot before starting the API (otherwise `/ready` reports `redis_ping: false` and the log spams `ioredis ECONNREFUSED`; the API still serves core routes via a synchronous fallback).
+
+### apps/api (NestJS REST API — the core product)
+- Needs `apps/api/.env.local`. `SUPABASE_URL` and `SUPABASE_SECRET_KEY` are required for boot but **placeholder values are enough to start the server** and serve `/health`, `/ready`, Swagger at `/api`, and the request/auth pipeline (unauthenticated → `401`). Real Supabase credentials are only needed for DB-backed RPC calls (actual payment/checkout creation). For local Redis add `REDIS_HOST=localhost` / `REDIS_PORT=6379`.
+- Run: `pnpm run start:dev` (watch) or `pnpm run build && pnpm run start:prod`. Listens on `http://localhost:3000`.
+- **Gotcha (incremental build):** `nest build` / `nest start --watch` use `deleteOutDir: true` plus TypeScript incremental caching. A stale `apps/api/tsconfig.build.tsbuildinfo` can make tsc skip emit after `dist` was deleted, so the app crashes with `Cannot find module dist/main`. Fix: `rm -f apps/api/tsconfig.build.tsbuildinfo` and rebuild.
+- **Tests (`pnpm test`):** most pass, but two suites fail in this environment by design: `src/core/__tests__/network-rpc.contract.spec.ts` reads SQL from the **private `apps/dashboard` submodule** (CI initializes it via a PAT — not available here), and `src/app.controller.spec.ts` has a DI gap (`ApiKeyGuard` now needs `RedisService` that the spec doesn't provide). These are unrelated to environment setup.
+
+### apps/cli (Rust CLI)
+- `cargo build` / `cargo test`. **Run tests single-threaded**: `cargo test -- --test-threads=1`. The `rules::installer` tests mutate the process-wide current directory and race under the default parallel runner (`install_cursor_rules` intermittently fails); single-threaded they all pass.
+
+### apps/docs (Next.js + Fumadocs)
+- `pnpm dev` / `pnpm build` / `pnpm lint` / `pnpm docs:drift`. Build uses the committed `apps/docs/openapi.json` by default (no API needed). Orama search env vars are optional. `pnpm build` regenerates some tracked files under `apps/docs/public/r/` — do not commit those build artifacts.
+
+### apps/mcp, apps/sdks
+- `apps/mcp`: `pnpm run build` (runs codegen prebuild) / `pnpm test` (vitest). `apps/sdks/ts` and `apps/sdks/embed`: `pnpm run build`; embed also has `pnpm test`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Adds an `AGENTS.md` documenting how to set up, run, lint, test, and build the open-source apps in this monorepo inside a Cursor Cloud environment. No application code is modified.

## Why
The monorepo has no root package manager and several non-obvious environment gotchas (Rust edition-2024 requirement, Redis for the API queues, a stale `tsbuildinfo` build gotcha, a flaky parallel CLI test, and two tests that need the private `apps/dashboard` submodule). Capturing these lets future agents/developers start services reliably.

## How
- Verified each open-source app installs and runs; recorded durable, non-obvious caveats in `AGENTS.md` under `## Cursor Cloud specific instructions`.
- Set the startup update script to per-app `pnpm install` (dependency refresh only).

## Testing
Verified in a fresh environment:

| App | Commands verified |
|-----|-------------------|
| `apps/api` | `pnpm run build`, `pnpm run lint` (0 errors), `pnpm test` (402/403; 2 suites need the private `apps/dashboard` submodule / have a pre-existing DI gap), `pnpm run start:dev` → `/health`, `/ready` (all checks green with Redis), `/api` Swagger, auth pipeline `401`s |
| `apps/docs` | `pnpm lint`, `pnpm docs:drift`, `pnpm build` |
| `apps/cli` | `cargo build`, `cargo test -- --test-threads=1` (9/9), binary runs |
| `apps/mcp` | `pnpm run build`, `pnpm test` (53/53) |
| `apps/sdks/ts` | `pnpm run build` |
| `apps/sdks/embed` | `pnpm run build`, `pnpm test` (8/8) |

### Demo — lomi. payment API running locally
[lomi_api_swagger_demo.mp4](https://cursor.com/agents/bc-13533e03-e397-4cfd-a121-4e030af4af14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flomi_api_swagger_demo.mp4)

[Swagger UI overview](https://cursor.com/agents/bc-13533e03-e397-4cfd-a121-4e030af4af14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_swagger_overview.webp)
[POST /checkout-sessions endpoint](https://cursor.com/agents/bc-13533e03-e397-4cfd-a121-4e030af4af14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_checkout_session_endpoint.webp)
[/ready health check](https://cursor.com/agents/bc-13533e03-e397-4cfd-a121-4e030af4af14/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_ready_check.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13533e03-e397-4cfd-a121-4e030af4af14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13533e03-e397-4cfd-a121-4e030af4af14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

