### PR TITLE
docs(ecommerce): add Bubble plugin page + cross-links; fix README shopify path

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We are progressively open-sourcing the monorepo toward **eventual self-hosting**
 
 - **Opening soon**:
   - Merchant dashboard: **[apps/dashboard](./apps/dashboard)**
-  - Shopify extension: **[apps/shopify](./apps/shopify)**
+  - Shopify extension: **[apps/plugins/shopify](./apps/plugins/shopify)**
 
 - **Proprietary**:
   - Admin dashboard: **[apps/admin](./apps/admin)**

--- a/apps/docs/content/docs/build/ecommerce-extensions/bubble.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/bubble.fr.mdx
@@ -1,0 +1,115 @@
+---
+title: Bubble
+description:
+  Ajoutez l’extension lomi. à votre application Bubble.io et acceptez les
+  paiements par checkout hébergé, sans code.
+---
+
+import { Callout } from '@/components/docs/docs-callout';
+
+# Bubble
+
+Connectez votre application **Bubble.io** au **checkout hébergé lomi.**. Le client paie sur une page lomi. sécurisée (redirection ou fenêtre intégrée) ; vos Things Bubble se mettent à jour automatiquement quand le paiement réussit.
+
+<Callout type="info" title="Pour qui est ce guide">
+  **Créateurs no-code** : il vous faut seulement une application Bubble, un compte lomi. et cette page. Les actions serveur choisissent le bon hôte d’API à partir de votre clé ; aucune URL de base à configurer.
+</Callout>
+
+## Avant de commencer
+
+| Prérequis | Détails |
+| --- | --- |
+| Application Bubble | Tout plan payant qui prend en charge les extensions installées |
+| Version d’API du plugin | **4** (dans l’onglet **Shared** du plugin) |
+| Devise de la boutique | **XOF**, **USD** ou **EUR** |
+| Compte lomi. | [En créer un gratuitement](https://dashboard.lomi.africa/onboarding) |
+| HTTPS | Les applications Bubble sont en HTTPS par défaut (requis pour les webhooks et les URL de retour) |
+
+## Étape 1, Récupérer vos clés d’API lomi.
+
+1. Connectez-vous à [dashboard.lomi.africa](https://dashboard.lomi.africa).
+2. Ouvrez **Paramètres → Jetons d’accès** (ou **Développeurs → Clés d’API**).
+3. Copiez votre **clé secrète de test** (`lomi_sk_test_…`) ; vous la collerez dans Bubble à l’étape 3.
+4. Depuis **Développeurs → Webhooks**, vous copierez aussi un **secret de signature** (`whsec_…`) à l’étape 6.
+
+Gardez le **mode Test** activé pendant l’intégration. Voir [Clés d’API](/start/api-keys).
+
+## Étape 2, Ajouter l’extension lomi. dans Bubble
+
+1. Dans l’éditeur Bubble, ouvrez l’onglet **Plugins** → **Add plugins**.
+2. Installez **lomi.** (ou, pour une version privée, synchronisez le dépôt [`lomiafrica/bubble`](https://github.com/lomiafrica/bubble) depuis **Plugins → Version → Synchronize with GitHub**).
+3. Ouvrez l’onglet **Shared** du plugin et vérifiez que la **version d’API** est **4**.
+
+## Étape 3, Saisir vos clés
+
+Ouvrez **Plugins → lomi.** dans votre application et remplissez les champs par environnement :
+
+| Champ | Développement (test) | Production (live) |
+| --- | --- | --- |
+| Clé secrète d’API | `lomi_sk_test_…` | `lomi_sk_live_…` |
+| Secret de webhook | `whsec_…` (endpoint de test) | `whsec_…` (endpoint live) |
+
+Les actions serveur choisissent `sandbox.api.lomi.africa` ou `api.lomi.africa` selon le préfixe de la clé ; aucun hôte à définir.
+
+## Étape 4, Construire le workflow de paiement
+
+Sur votre bouton **Payer**, exécutez ces actions dans l’ordre :
+
+1. **Create checkout session** (serveur) : renseignez `amount` (XOF en francs entiers ; USD/EUR en unités majeures), `currency_code`, et vos `success_url` / `cancel_url`. Renseignez `bubble_thing_type` et `bubble_thing_id` pour que le webhook retrouve le bon Thing ensuite.
+2. **Mark checkout redirect** (client) : à appeler avant la redirection (l’élément **lomi. Pay button** le fait pour vous).
+3. **Redirect to checkout** (client) avec le `checkout_url` renvoyé à l’étape 1, **ou** placez l’élément **lomi. Pay button** et liez son **Checkout URL** à ce résultat.
+
+Chaque session créée ainsi est marquée `integration_source: bubble` automatiquement.
+
+## Étape 5, Compléter ou abandonner sur la page de succès
+
+Sur votre page `success_url` :
+
+1. Lisez `session_id` depuis l’URL de la page (**Get data from page URL**).
+2. Exécutez **Complete if paid** avec ce `session_id`.
+3. Si `paid` vaut **yes**, marquez votre Thing comme payé et affichez la confirmation.
+4. Si `paid` vaut **no**, exécutez **Abandon checkout**. Un retour navigateur après redirection déclenche aussi `lomi:checkout-abandon` (géré nativement) ; aucune configuration supplémentaire n’est nécessaire pour la récupération de panier.
+
+## Étape 6, Connecter les webhooks
+
+Les webhooks confirment le paiement même si le client ferme l’onglet avant de revenir.
+
+1. Exposez un workflow backend en tant qu’endpoint **POST API** dans Bubble.
+2. Dans ce workflow, exécutez **Verify and parse webhook** avec le corps **brut** et l’en-tête `X-Lomi-Signature`.
+3. Branchez sur **`PAYMENT_SUCCEEDED`** → marquez le Thing payé (de façon idempotente pour qu’un doublon soit sans effet).
+4. Branchez sur **`REFUND_COMPLETED`** → marquez le Thing remboursé.
+5. Dans [dashboard.lomi.africa](https://dashboard.lomi.africa) → **Développeurs → Webhooks**, ajoutez l’URL de votre endpoint Bubble, activez **`PAYMENT_SUCCEEDED`** et **`REFUND_COMPLETED`**, puis recollez le **secret de signature** dans **Plugins → lomi.**.
+
+## Étape 7, Faire un paiement de test
+
+1. Prévisualisez votre application et cliquez sur le bouton **Payer**.
+2. Vous êtes envoyé vers **lomi. Checkout** (sandbox tant que votre clé de test est utilisée).
+3. Payez avec la carte de test **`4242 4242 4242 4242`** (date future, CVC au choix). Voir [Paiements sandbox](/start/sandbox-payments).
+4. Vérifiez que la page de succès affiche `paid = yes` et que votre Thing est marqué payé.
+5. Si le Thing reste impayé, vérifiez que le secret de webhook correspond et que **`PAYMENT_SUCCEEDED`** est activé sur votre endpoint.
+
+## Passer en production
+
+Quand vous êtes prêt pour des paiements réels :
+
+1. Basculez votre application sur sa version **live** et utilisez les champs de clé **Production**.
+2. Collez votre **clé secrète live** et votre **secret de webhook live** (créez un endpoint de webhook **live** dans le tableau de bord pointant vers votre URL Bubble live).
+3. Effectuez un petit paiement réel et vérifiez que le Thing se complète.
+
+Voir aussi [Vérifier les paiements](/build/guides/verify-payments).
+
+## Remboursements, mode intégré et référence
+
+**Remboursements** : depuis le [tableau de bord](https://dashboard.lomi.africa) ; le webhook `REFUND_COMPLETED` met à jour votre Thing.
+
+**Mode intégré** : réglez le **lomi. Pay button** (ou **Open checkout embed**) sur `embed` pour garder le client dans votre application ; écoutez `oncomplete` ou l’événement window `lomi:checkout-complete`. Cela réutilise le [widget d’intégration](/build/embed-widget).
+
+**En-têtes de webhook** : `X-Lomi-Event`, `X-Lomi-Signature` (HMAC-SHA256 hex du corps brut). Détails : [Traiter les webhooks](/build/advanced-guides/handling-webhooks) et [Webhooks](/build/webhooks).
+
+## Pour les développeurs
+
+GitHub, la construction des assets d’intégration et les détails d’API sont documentés séparément :
+
+- [Hub e‑commerce](/build/ecommerce-extensions), contrat d’API partagé
+- [dépôt bubble](https://github.com/lomiafrica/bubble), source de l’extension et `docs/SETUP.md`
+- Chaîne d’assets d’intégration : construire l’IIFE `@lomi./embed`, puis lancer `scripts/build-assets.mjs` (contributeurs uniquement)

--- a/apps/docs/content/docs/build/ecommerce-extensions/bubble.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/bubble.mdx
@@ -1,0 +1,115 @@
+---
+title: Bubble
+description:
+  Add the lomi. plugin to your Bubble.io app and accept hosted checkout
+  payments, no code required.
+---
+
+import { Callout } from '@/components/docs/docs-callout';
+
+# Bubble
+
+Connect your **Bubble.io** app to **lomi. hosted checkout**. Shoppers pay on a secure lomi. page (redirect or embedded modal); your Bubble Things update automatically when payment succeeds.
+
+<Callout type="info" title="Who this guide is for">
+  **No-code makers**: you only need a Bubble app, a lomi. account, and this page. Server actions pick the correct API host from your key, so there is no base URL to configure.
+</Callout>
+
+## Before you start
+
+| Requirement | Details |
+| --- | --- |
+| Bubble app | Any paid plan that supports installed plugins |
+| Plugin API version | **4** (set in the plugin **Shared** tab) |
+| Store currency | **XOF**, **USD**, or **EUR** |
+| lomi. account | [Create one free](https://dashboard.lomi.africa/onboarding) |
+| HTTPS | Bubble apps are HTTPS by default (required for webhooks and return URLs) |
+
+## Step 1, Get your lomi. API keys
+
+1. Sign in to [dashboard.lomi.africa](https://dashboard.lomi.africa).
+2. Open **Settings → Access tokens** (or **Developers → API keys**).
+3. Copy your **Test secret key** (`lomi_sk_test_…`); you will paste it into Bubble in step 3.
+4. From **Developers → Webhooks**, you will also copy a **signing secret** (`whsec_…`) in step 6.
+
+Keep **Test mode** on while integrating. See [API keys](/start/api-keys) for details.
+
+## Step 2, Add the lomi. plugin in Bubble
+
+1. In the Bubble editor, open the **Plugins** tab → **Add plugins**.
+2. Install **lomi.** (or, for a private build, sync the [`lomiafrica/bubble`](https://github.com/lomiafrica/bubble) repo from **Plugins → Version → Synchronize with GitHub**).
+3. Open the plugin **Shared** tab and confirm **Plugin API version** is **4**.
+
+## Step 3, Enter your keys
+
+Open **Plugins → lomi.** in your app and fill the environment-specific fields:
+
+| Field | Development (test) | Production (live) |
+| --- | --- | --- |
+| API secret key | `lomi_sk_test_…` | `lomi_sk_live_…` |
+| Webhook secret | `whsec_…` (test endpoint) | `whsec_…` (live endpoint) |
+
+Server actions select `sandbox.api.lomi.africa` or `api.lomi.africa` from the key prefix automatically, there is no host to set.
+
+## Step 4, Build the checkout workflow
+
+On your **Pay** button, run these actions in order:
+
+1. **Create checkout session** (server): set `amount` (XOF whole francs; USD/EUR major units), `currency_code`, and your `success_url` / `cancel_url`. Set `bubble_thing_type` and `bubble_thing_id` so the webhook can find the right Thing later.
+2. **Mark checkout redirect** (client): call before redirecting (the **lomi. Pay button** element does this for you).
+3. **Redirect to checkout** (client) with the `checkout_url` returned in step 1, **or** drop the **lomi. Pay button** element and bind its **Checkout URL** to that result.
+
+Every session created this way is tagged with `integration_source: bubble` automatically.
+
+## Step 5, Complete or abandon on the success page
+
+On your `success_url` page:
+
+1. Read `session_id` from the page URL (**Get data from page URL**).
+2. Run **Complete if paid** with that `session_id`.
+3. If `paid` is **yes**, mark your Thing paid and show confirmation.
+4. If `paid` is **no**, run **Abandon checkout**. A browser back after redirect also fires `lomi:checkout-abandon` (handled out of the box), so no extra configuration is needed for cart recovery.
+
+## Step 6, Connect webhooks
+
+Webhooks confirm payment even if the shopper closes the tab before returning.
+
+1. Expose a backend workflow as a **POST API** endpoint in Bubble.
+2. In that workflow, run **Verify and parse webhook** with the **raw** body and the `X-Lomi-Signature` header.
+3. Branch on **`PAYMENT_SUCCEEDED`** → mark the Thing paid (make it idempotent so a duplicate event is safe).
+4. Branch on **`REFUND_COMPLETED`** → mark the Thing refunded.
+5. In [dashboard.lomi.africa](https://dashboard.lomi.africa) → **Developers → Webhooks**, add your Bubble endpoint URL, enable **`PAYMENT_SUCCEEDED`** and **`REFUND_COMPLETED`**, and paste the **signing secret** back into **Plugins → lomi.**.
+
+## Step 7, Run a test payment
+
+1. Preview your app and click the **Pay** button.
+2. You are sent to **lomi. Checkout** (sandbox while your test key is set).
+3. Pay with test card **`4242 4242 4242 4242`** (any future expiry, any CVC). See [Sandbox payments](/start/sandbox-payments).
+4. Confirm the success page shows `paid = yes` and your Thing is marked paid.
+5. If the Thing stays unpaid, check that the webhook secret matches and **`PAYMENT_SUCCEEDED`** is enabled on your dashboard endpoint.
+
+## Go live
+
+When you are ready for real payments:
+
+1. Switch your app to its **live** version and use the **Production** key fields.
+2. Paste your **Live secret key** and **Live webhook secret** (create a **live** webhook endpoint in the dashboard pointing at your live Bubble URL).
+3. Run one small real payment and confirm the Thing completes.
+
+See also [Verify payments](/build/guides/verify-payments).
+
+## Refunds, embed mode, and reference
+
+**Refunds**: issue from the [dashboard](https://dashboard.lomi.africa); the `REFUND_COMPLETED` webhook updates your Thing.
+
+**Embed mode**: set the **lomi. Pay button** (or **Open checkout embed**) to `embed` to keep shoppers in your app; listen for `oncomplete` or the `lomi:checkout-complete` window event. This reuses the [embed widget](/build/embed-widget).
+
+**Webhook headers**: `X-Lomi-Event`, `X-Lomi-Signature` (HMAC-SHA256 hex of the raw body). Details: [Handling webhooks](/build/advanced-guides/handling-webhooks) and [Webhooks](/build/webhooks).
+
+## For developers
+
+GitHub, embed asset builds, and API internals are documented separately:
+
+- [E‑commerce hub](/build/ecommerce-extensions), shared API contract
+- [bubble repository](https://github.com/lomiafrica/bubble), plugin source and `docs/SETUP.md`
+- Embed asset chain: build `@lomi./embed` IIFE, then run `scripts/build-assets.mjs` (contributors only)

--- a/apps/docs/content/docs/build/ecommerce-extensions/index.fr.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/index.fr.mdx
@@ -41,6 +41,7 @@ Avant la mise en production : [Intégration API](/start/first-payment), [Authen
 | Magento 2 | Composer VCS depuis [magento](https://github.com/lomiafrica/magento) ou copie dans `app/code/Lomi/Payments/` |
 | PrestaShop | Zip du dossier `lomi/` depuis [prestashop](https://github.com/lomiafrica/prestashop) |
 | Shopify | [Tableau de bord](https://dashboard.lomi.africa) → **Paramètres → Canaux de paiement → Intégrations** (installation personnalisée, pas de zip) |
+| Bubble | [Éditeur Bubble](https://bubble.io/home/plugins) → **Plugins → Add plugins → lomi.** (ou sync GitHub), [installation](/build/ecommerce-extensions/bubble) pas à pas |
 
 ## Choisir la plateforme
 
@@ -65,8 +66,33 @@ Avant la mise en production : [Intégration API](/start/first-payment), [Authen
     description="App personnalisée, paiement panier mobile money et cartes"
     href="/build/ecommerce-extensions/shopify"
   />
+  <Card
+    title="Bubble"
+    description="Extension no-code Bubble.io, checkout par redirection ou intégré"
+    href="/build/ecommerce-extensions/bubble"
+  />
 </Cards>
 
 <Callout type="info">
   **Shopify** est distribué en **installation personnalisée**. Activez-le depuis le tableau de bord lomi. → **Intégrations**, puis installez sur votre boutique via OAuth.
 </Callout>
+
+## Autres façons d’intégrer
+
+Pas sur une plateforme prise en charge, ou vous construisez un tunnel personnalisé ? Ces options offrent le même checkout hébergé sans extension de boutique :
+
+- **[Widget d’intégration](/build/embed-widget)**, un bouton et une fenêtre de checkout à intégrer sur n’importe quel site (y compris Bubble et HTML personnalisé).
+- **[Checkout hébergé](/build/checkout)**, la page lomi. vers laquelle vos extensions redirigent les clients.
+- **[lomi-ui](/build/lomi-ui)**, des composants de checkout à copier-coller quand vous voulez votre propre UI.
+- **[CLI](/build/cli)**, créer et tester des sessions de paiement depuis votre terminal.
+- **[MCP](/build/mcp)**, piloter le checkout depuis des agents IA et vos workflows d’IDE.
+
+## Extension, widget ou API ?
+
+| Vous voulez… | Utilisez |
+| --- | --- |
+| Ajouter les paiements à une boutique prise en charge (Woo, Magento, PrestaShop, Shopify, Bubble) | L’**extension** de cette plateforme |
+| Ajouter un bouton de paiement à un site personnalisé ou une page no-code | **[Widget d’intégration](/build/embed-widget)** |
+| Garder votre propre UI de checkout sans recoder la plomberie de paiement | Les composants **[lomi-ui](/build/lomi-ui)** |
+| Un contrôle total depuis votre propre backend | L’**[API publique](/start/first-payment)** (`POST /checkout-sessions`) |
+| Automatiser ou tester depuis un terminal ou des agents IA | **[CLI](/build/cli)** ou **[MCP](/build/mcp)** |

--- a/apps/docs/content/docs/build/ecommerce-extensions/index.mdx
+++ b/apps/docs/content/docs/build/ecommerce-extensions/index.mdx
@@ -41,6 +41,7 @@ Before going live, also read [API integration](/start/first-payment), [Authentic
 | Magento 2 | Composer VCS from [magento](https://github.com/lomiafrica/magento) or copy to `app/code/Lomi/Payments/` |
 | PrestaShop | Zip the `lomi/` folder from [prestashop](https://github.com/lomiafrica/prestashop) |
 | Shopify | [Dashboard](https://dashboard.lomi.africa) → **Settings → Payment channels → Integrations** (custom install, no zip) |
+| Bubble | [Bubble editor](https://bubble.io/home/plugins) → **Plugins → Add plugins → lomi.** (or GitHub sync), step-by-step [setup](/build/ecommerce-extensions/bubble) |
 
 ## Choose your platform
 
@@ -65,8 +66,33 @@ Before going live, also read [API integration](/start/first-payment), [Authentic
     description="Custom app, cart pay with mobile money and cards"
     href="/build/ecommerce-extensions/shopify"
   />
+  <Card
+    title="Bubble"
+    description="No-code Bubble.io plugin, redirect or embedded checkout"
+    href="/build/ecommerce-extensions/bubble"
+  />
 </Cards>
 
 <Callout type="info">
   **Shopify** is distributed as a **custom install app** (not App Store payments). Enable it from [dashboard.lomi.africa](https://dashboard.lomi.africa) → **Settings → Payment channels → Integrations**, then install on your store via OAuth.
 </Callout>
+
+## Other ways to integrate
+
+Not on a supported platform, or building a custom flow? These give you the same hosted checkout without a store plugin:
+
+- **[Embed widget](/build/embed-widget)**, a drop-in checkout button and modal for any site (including Bubble and custom HTML).
+- **[Hosted checkout](/build/checkout)**, the lomi. page your plugins redirect shoppers to.
+- **[lomi-ui](/build/lomi-ui)**, copy-paste checkout components when you want your own UI.
+- **[CLI](/build/cli)**, create and test checkout sessions from your terminal.
+- **[MCP](/build/mcp)**, drive checkout from AI agents and IDE workflows.
+
+## Plugin, embed, or API?
+
+| You want to… | Use |
+| --- | --- |
+| Add payments to a supported store (Woo, Magento, PrestaShop, Shopify, Bubble) | The **plugin** for that platform |
+| Add a checkout button to a custom site or no-code page | **[Embed widget](/build/embed-widget)** |
+| Keep your own checkout UI but skip the payment plumbing | **[lomi-ui](/build/lomi-ui)** components |
+| Full control from your own backend | The **[public API](/start/first-payment)** (`POST /checkout-sessions`) |
+| Automate or test from a terminal or AI agents | **[CLI](/build/cli)** or **[MCP](/build/mcp)** |

--- a/apps/docs/content/docs/build/ecommerce-extensions/meta.json
+++ b/apps/docs/content/docs/build/ecommerce-extensions/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "E‑commerce",
-  "description": "Hosted checkout plugins for WooCommerce, Magento, PrestaShop, and Shopify.",
+  "description": "Hosted checkout plugins for WooCommerce, Magento, PrestaShop, Shopify, and Bubble.",
   "icon": "Store",
-  "pages": ["index", "woocommerce", "magento", "prestashop", "shopify"]
+  "pages": ["index", "woocommerce", "magento", "prestashop", "shopify", "bubble"]
 }


### PR DESCRIPTION
## Summary

Addresses the in-repo documentation deliverables from #41 and #42, and fixes a broken README link.

- **Bubble docs page (EN + FR)** — new `bubble.mdx` / `bubble.fr.mdx` mirroring the WooCommerce setup structure (keys → install → workflow → success/abandon → webhooks → test → go live). Closes the "no Bubble page" gap called out in #41. Content is derived from the Bubble plugin's own `docs/SETUP.md` and `README.md`.
- **Index integration** — Bubble added to `meta.json` sidebar, the "Choose your platform" cards, and the install table.
- **Cross-links (#42)** — new **"Other ways to integrate"** section and a **"Plugin, embed, or API?"** decision guide on the e-commerce index (EN + FR), linking embed widget, hosted checkout, lomi-ui, CLI, and MCP.
- **README fix (#42)** — `apps/shopify` → `apps/plugins/shopify` (the old link was dead).

## Verification

- `dt check` → `status: ok` (lint, docs_drift, screenshots all passed).
- `dt sync-i18n --check` → the new EN/FR pair adds **0** issues (repo total stays at its pre-existing 47; see note below).
- `pnpm exec fumadocs-mdx` compiles all MDX.

## Notes / out of scope

- The **47 pre-existing `dt sync-i18n` issues** are chronic on `main` (structure mismatches on auto-generated `api/**` reference pages + 3 hand-written `build/**` pages). They predate this PR and are unrelated; tracked separately.
- Full closure of #40/#41/#42 also needs private-submodule plugin code, website submodule, screenshots, and CI hardening — not included here.

## Test plan

- [ ] Preview docs build renders `/build/ecommerce-extensions/bubble` (EN + FR) and the updated index.
- [ ] Confirm all new internal links resolve.

Made with [Cursor](https://cursor.com)