### PR TITLE
fix(docs): restore '-' placeholder in API reference generator

### DIFF
--- a/apps/docs/lib/scripts/manual-api/render-operation-mdx.ts
+++ b/apps/docs/lib/scripts/manual-api/render-operation-mdx.ts
@@ -299,7 +299,7 @@ function paramRow(
       ? escapeMdxText(p.description)
       : '';
   const nameCell = '`' + (p.name ?? '') + '`';
-  const schemaCell = schema ? `\`${schema}\`` : ', ';
+  const schemaCell = schema ? `\`${schema}\`` : '-';
   return `| ${nameCell} | ${String(p.in)} | ${required} | ${schemaCell} | ${desc} |`;
 }
 
@@ -335,7 +335,7 @@ function responseRows(
           ? escapeMdxText(englishResponseDescription(code, openApiDesc))
           : escapeMdxText(openApiDesc);
     }
-    rows.push(`| \`${code}\` | ${desc || ', '} |`);
+    rows.push(`| \`${code}\` | ${desc || '-'} |`);
   }
   return rows;
 }
@@ -403,7 +403,7 @@ function buildRequestBodySection(
         ? escapeMdxText(fieldSchema.description)
         : '';
       lines.push(
-        `| \`${field}\` | ${required.has(field) ? labels.yes : labels.no} | \`${fieldType}\` | ${fieldDesc || ', '} |`,
+        `| \`${field}\` | ${required.has(field) ? labels.yes : labels.no} | \`${fieldType}\` | ${fieldDesc || '-'} |`,
       );
     }
     lines.push('');
@@ -536,7 +536,7 @@ export function renderOperationPageMdx(input: {
                 'description' in p && typeof p.description === 'string'
                   ? escapeMdxText(p.description)
                   : '';
-              return `| \`${p.name}\` | ${req} | ${schema ? `\`${schema}\`` : ', '} | ${desc} |`;
+              return `| \`${p.name}\` | ${req} | ${schema ? `\`${schema}\`` : '-'} | ${desc} |`;
             }),
           )
           .join('\n');


### PR DESCRIPTION
## Summary

While investigating the chronic `dt sync-i18n` failure, I found the manual API reference generator (`render-operation-mdx.ts`) emits a literal `, ` into empty **Schema**, **response-description**, and **request-body-field** table cells. The committed pages use `-` (from an earlier generator version), so running `pnpm run api:regenerate-rest-reference` today would corrupt ~70 pages with stray commas (e.g. `| id | Yes | ,  | ... |`).

This restores the intended `-` placeholder in all four table builders.

- **No committed doc pages change** — this only makes the generator reproduce the current committed output instead of regressing it.

## Not included (deliberately)

The 47 `dt sync-i18n` issues are a **separate** problem: EN/FR structural asymmetry (e.g. EN pages have a `### See also` section that the FR copy in `fr-operation-overrides.ts` lacks). Fixing those requires authoring FR translation parity per operation (regeneration alone leaks English into FR pages), which is not a safe mechanical change. Tracked as follow-up.

## Test plan

- [ ] `CONFIRM_BOOTSTRAP=1 BOOTSTRAP_OVERWRITE=1 pnpm run api:regenerate-rest-reference` yields no `, ` cells and no spurious EN diffs.

Made with [Cursor](https://cursor.com)