### PR TITLE
fix(docs): fix Relay link in WhatsApp Commerce page

### DIFF
--- a/apps/docs/content/docs/build/whatsapp-commerce.mdx
+++ b/apps/docs/content/docs/build/whatsapp-commerce.mdx
@@ -19,7 +19,7 @@ WhatsApp Commerce on lomi. combines **payment links**, **hosted checkout**, and 
 
 ## Related integrations
 
-- [Relay](/relay) on lomi.africa covers store plugins plus social selling in one story.
+- [Relay](https://lomi.africa/relay) on lomi.africa covers store plugins plus social selling in one story.
 - [Payment links](/build/payment-links) for no-code sales without a website.
 - [Hosted checkout](/build/checkout) when your backend creates checkout sessions for every order.
 


### PR DESCRIPTION
## Summary
- Relative `/relay` fails `build-docs` link lint (not a docs route).
- Point EN WhatsApp Commerce page at `https://lomi.africa/relay`, matching FR.

## Test plan
- [ ] `pnpm lint` in `apps/docs` no longer reports `/relay` not-found

Made with [Cursor](https://cursor.com)