### PR TITLE
Add Resend webhook on api.lomi.africa for trylomi.com

### DIFF
--- a/apps/docs/agent-openapi.json
+++ b/apps/docs/agent-openapi.json
@@ -948,6 +948,7 @@
     },
     "/oauth/register": {
       "post": {
+        "description": "Unknown client metadata is ignored (RFC 7591). MCP clients such as Cursor send extra fields like application_type.",
         "operationId": "OAuthController_registerClient",
         "parameters": [
           {
@@ -961,6 +962,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OAuthRegisterClientDto"
+              }
+            }
+          }
+        },
         "responses": {
           "201": {
             "description": ""
@@ -1232,6 +1243,42 @@
       "CreateHandoffDto": {
         "type": "object",
         "properties": {}
+      },
+      "OAuthRegisterClientDto": {
+        "type": "object",
+        "properties": {
+          "client_name": {
+            "type": "string"
+          },
+          "redirect_uris": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "grant_types": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "response_types": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "token_endpoint_auth_method": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "client_name",
+          "redirect_uris"
+        ]
       }
     }
   }

--- a/apps/docs/agent-openapi.json
+++ b/apps/docs/agent-openapi.json
@@ -948,7 +948,6 @@
     },
     "/oauth/register": {
       "post": {
-        "description": "Unknown client metadata is ignored (RFC 7591). MCP clients such as Cursor send extra fields like application_type.",
         "operationId": "OAuthController_registerClient",
         "parameters": [
           {
@@ -962,16 +961,6 @@
             }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OAuthRegisterClientDto"
-              }
-            }
-          }
-        },
         "responses": {
           "201": {
             "description": ""
@@ -1243,42 +1232,6 @@
       "CreateHandoffDto": {
         "type": "object",
         "properties": {}
-      },
-      "OAuthRegisterClientDto": {
-        "type": "object",
-        "properties": {
-          "client_name": {
-            "type": "string"
-          },
-          "redirect_uris": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "grant_types": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "response_types": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "token_endpoint_auth_method": {
-            "type": "string"
-          },
-          "scope": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "client_name",
-          "redirect_uris"
-        ]
       }
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Asked by Babacar via Chief of Staff. The trylomi.com Resend webhook currently posts to `https://api-production-e914.up.railway.app/resend/webhook` (BeeCargo / `api.beecargo.net`). `POST https://api.lomi.africa/resend/webhook` is 404 today. This pin adds a Svix verifier on the lomi. Nest API so CoS can move the Resend endpoint off BeeCargo.

Code lives in `lomiafrica/api` (`cursor/resend-webhook-routing-f488`, commit `aad6a85`). Railway project `lomi.` / service `API` deploys from that repo. Merge the API branch to deploy; this umbrella PR only pins the submodule.

BeeCargo is out of scope. Do not overwrite BeeCargo `RESEND_WEBHOOK_SECRET`.

## CoS: production cutover

**1. Webhook URL to put in Resend (trylomi account)**

`https://api.lomi.africa/resend/webhook`

**2. Railway env vars on project `lomi.` / service `API`**

Set now (trylomi signing secret, `whsec_…`):

- `RESEND_WEBHOOK_SECRET`

Optional extra inbound secret (do not replace the first; both are accepted):

- `RESEND_WEBHOOK_SECRET_TRYLOMI`

Either value may be a comma-separated list of `whsec_…` secrets. The verifier tries every configured secret, so a later `updates.lomi.africa` inbound key can be added without breaking trylomi.

Do not paste secrets into git or Slack. CoS holds the trylomi signing secret for Babacar.

**3. Order of operations**

1. Set `RESEND_WEBHOOK_SECRET` on Railway project `lomi.` / service `API`.
2. Merge/deploy the API so `POST /resend/webhook` exists on `api.lomi.africa`.
3. CoS updates the Resend dashboard endpoint from the BeeCargo Railway host to `https://api.lomi.africa/resend/webhook`.
4. Leave BeeCargo's existing `RESEND_WEBHOOK_SECRET` alone.

## Behavior

- Missing `svix-id` / `svix-timestamp` / `svix-signature` → 400
- Invalid signature → 400
- Valid → 200
- Handled events (log + wide event only, no CRM): `email.received`, `email.bounced`, `email.complained`, `email.delivered`, `email.failed`, `email.delivery_delayed`

## Verification

- API unit tests for Svix verify + event handling
- API CI-equivalent Jest: 550 passed
- `pnpm run typecheck` and `pnpm run build` passed in `apps/api`
- Confirmed current production `POST https://api.lomi.africa/resend/webhook` is 404 (`not_found`)

Out of scope: BeeCargo code/secrets, App Store, fees/rails.

## Investigation (discarded hunches)

- Path is `/resend/webhook`, not `/webhooks/resend`, so Resend only needs a host change.
- Did not call `claim_inbound_provider_webhook_event`: `provider_code` is WAVE/STRIPE/MTN/SPI/… and adding RESEND would invent schema.
- `audit-dashboard` browserslist highs already fail on `main`.
- Monorepo `build-api` `openapi:export:agent` fails on API main (`cb51c3b`) with a Nest swagger cycle on `OAuthRegisterClientDto.client_name`. Reproduced without this webhook. Not mixed into this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92dd6836-1313-4819-ba03-81ca1640f488?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92dd6836-1313-4819-ba03-81ca1640f488&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

