### PR TITLE
Wire Jumbo (lomi. Pos) into monorepo CI, audit, and docs

### DIFF
--- a/.github/workflows/app-ci-jumbo.yml
+++ b/.github/workflows/app-ci-jumbo.yml
@@ -1,0 +1,70 @@
+name: lomi · ci · jumbo
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "apps/jumbo/**"
+      - "packages/shared/**"
+      - "packages/queries/**"
+      - "tooling/scripts/install-app-with-packages.mjs"
+      - ".github/workflows/app-ci-jumbo.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/jumbo/**"
+      - "packages/shared/**"
+      - "packages/queries/**"
+      - "tooling/scripts/install-app-with-packages.mjs"
+      - ".github/workflows/app-ci-jumbo.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/jumbo
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Checkout jumbo submodule
+        working-directory: .
+        env:
+          TOKEN: ${{ secrets.REPO_CHECKOUT_PAT }}
+        run: bash .github/scripts/init-submodules.sh apps/jumbo
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: |
+            apps/jumbo/pnpm-lock.yaml
+            packages/shared/package.json
+            packages/queries/package.json
+
+      - name: Install Jumbo + shared packages
+        working-directory: .
+        run: node tooling/scripts/install-app-with-packages.mjs apps/jumbo
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Format
+        run: pnpm format
+
+      - name: Knip
+        run: pnpm knip
+
+      - name: Typecheck
+        run: pnpm exec tsc --noEmit --incremental false
+
+      - name: Test
+        run: pnpm exec jest --ci --watchman=false

--- a/.github/workflows/app-ci-jumbo.yml
+++ b/.github/workflows/app-ci-jumbo.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Format
-        run: pnpm format
-
       - name: Knip
         run: pnpm knip
 

--- a/.github/workflows/app-security-audit.yml
+++ b/.github/workflows/app-security-audit.yml
@@ -1,7 +1,7 @@
 name: lomi · security · dependency audit
 
 # Full installs are expensive: run on lockfile changes, weekly, or manually.
-# dashboard/checkout live in private submodule repos — check them out explicitly.
+# dashboard/checkout/jumbo live in private submodule repos — check them out explicitly.
 on:
   push:
     branches: [main, develop]
@@ -9,6 +9,7 @@ on:
       - "apps/api"
       - "apps/dashboard/pnpm-lock.yaml"
       - "apps/checkout/pnpm-lock.yaml"
+      - "apps/jumbo/pnpm-lock.yaml"
       - ".github/workflows/app-security-audit.yml"
   pull_request:
     branches: [main]
@@ -16,6 +17,7 @@ on:
       - "apps/api"
       - "apps/dashboard/pnpm-lock.yaml"
       - "apps/checkout/pnpm-lock.yaml"
+      - "apps/jumbo/pnpm-lock.yaml"
       - ".github/workflows/app-security-audit.yml"
   schedule:
     - cron: "30 8 * * 1"
@@ -85,6 +87,29 @@ jobs:
           ref: main
           token: ${{ secrets.REPO_CHECKOUT_PAT }}
           path: apps/checkout
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: pnpm audit (high and critical)
+        run: pnpm --ignore-workspace audit --audit-level high
+
+  audit-jumbo:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/jumbo
+    steps:
+      - uses: actions/checkout@v5
+      - name: Checkout jumbo submodule
+        uses: actions/checkout@v5
+        with:
+          repository: lomiafrica/jumbo
+          ref: main
+          token: ${{ secrets.REPO_CHECKOUT_PAT }}
+          path: apps/jumbo
       - uses: pnpm/action-setup@v4
         with:
           version: 9

--- a/.github/workflows/app-security-audit.yml
+++ b/.github/workflows/app-security-audit.yml
@@ -1,7 +1,7 @@
 name: lomi · security · dependency audit
 
 # Full installs are expensive: run on lockfile changes, weekly, or manually.
-# dashboard/checkout/jumbo live in private submodule repos — check them out explicitly.
+# dashboard/checkout live in private submodule repos — check them out explicitly.
 on:
   push:
     branches: [main, develop]
@@ -9,7 +9,6 @@ on:
       - "apps/api"
       - "apps/dashboard/pnpm-lock.yaml"
       - "apps/checkout/pnpm-lock.yaml"
-      - "apps/jumbo/pnpm-lock.yaml"
       - ".github/workflows/app-security-audit.yml"
   pull_request:
     branches: [main]
@@ -17,7 +16,6 @@ on:
       - "apps/api"
       - "apps/dashboard/pnpm-lock.yaml"
       - "apps/checkout/pnpm-lock.yaml"
-      - "apps/jumbo/pnpm-lock.yaml"
       - ".github/workflows/app-security-audit.yml"
   schedule:
     - cron: "30 8 * * 1"
@@ -87,29 +85,6 @@ jobs:
           ref: main
           token: ${{ secrets.REPO_CHECKOUT_PAT }}
           path: apps/checkout
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-      - name: pnpm audit (high and critical)
-        run: pnpm --ignore-workspace audit --audit-level high
-
-  audit-jumbo:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: apps/jumbo
-    steps:
-      - uses: actions/checkout@v5
-      - name: Checkout jumbo submodule
-        uses: actions/checkout@v5
-        with:
-          repository: lomiafrica/jumbo
-          ref: main
-          token: ${{ secrets.REPO_CHECKOUT_PAT }}
-          path: apps/jumbo
       - uses: pnpm/action-setup@v4
         with:
           version: 9

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,6 +24,7 @@
 [submodule "apps/jumbo"]
 	path = apps/jumbo
 	url = https://github.com/lomiafrica/jumbo.git
+	branch = main
 [submodule "apps/customers"]
 	path = apps/customers
 	url = https://github.com/lomiafrica/customers.git

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ We are progressively open-sourcing the monorepo toward **eventual self-hosting**
 - **Proprietary**:
   - API service: **[apps/api](./apps/api)** (`lomiafrica/api`)
   - Admin dashboard: **[apps/admin](./apps/admin)**
+  - Merchant phone app (lomi. Pos): **[apps/jumbo](./apps/jumbo)** (`lomiafrica/jumbo`)
 
 All open-source repositories will be merged into the monorepo in the coming months.
 

--- a/apps/docs/content/docs/resources/open-source.fr.mdx
+++ b/apps/docs/content/docs/resources/open-source.fr.mdx
@@ -29,6 +29,7 @@ Certains composants relèvent exclusivement de notre **licence commerciale**, po
 | Site de documentation | ✅ Open source (`apps/docs`) |
 | Tableau de bord marchand, checkout, storefront | 🔒 Produit hébergé (ouverture progressive du code) |
 | Admin | 🔒 Propriétaire |
+| Application marchande lomi. Pos | 🔒 Propriétaire (`apps/jumbo`) |
 
 <Callout type="warn">
   **Pas d’auto-hébergement aujourd’hui.** Le traitement des paiements repose sur l’infrastructure hébergée de lomi., Merchant of Record, accords prestataires, conformité et stack opérationnelle. Un clone local sert au **développement et à la contribution**, pas à exploiter votre propre processeur de paiement.
@@ -87,6 +88,7 @@ Ce qui est ouvert aujourd’hui :
 
 - **Propriétaire** :
   - Tableau de bord admin : **`apps/admin`**
+  - Application marchande lomi. Pos : **`apps/jumbo`** (`lomiafrica/jumbo`)
 
 - **Produit hébergé (code pas entièrement public)** :
   - Checkout : **`apps/checkout`**

--- a/apps/docs/content/docs/resources/open-source.mdx
+++ b/apps/docs/content/docs/resources/open-source.mdx
@@ -29,6 +29,7 @@ Certain components are covered exclusively by our **commercial license**, design
 | Documentation website | ✅ Open source (`apps/docs`) |
 | Merchant dashboard, checkout, storefront | 🔒 Hosted product (source opening progressively) |
 | Admin | 🔒 Proprietary |
+| Merchant phone app (lomi. Pos) | 🔒 Proprietary (`apps/jumbo`) |
 
 <Callout type="warn">
   **Not self-hostable today.** Running payment processing requires lomi.’s hosted infrastructure, Merchant of Record, provider agreements, compliance, and operational stack. Local clones are for **development and contribution**, not for operating your own payment processor.
@@ -87,6 +88,7 @@ What is open today:
 
 - **Proprietary**:
   - Admin dashboard: **`apps/admin`**
+  - Merchant phone app (lomi. Pos): **`apps/jumbo`** (`lomiafrica/jumbo`)
 
 - **Hosted product (source not fully public yet)**:
   - Checkout: **`apps/checkout`**

--- a/tooling/tasks.json
+++ b/tooling/tasks.json
@@ -293,7 +293,7 @@
       ],
       "owner": "mobile",
       "risk": "medium",
-      "notes": "dev is the Expo bundler. start is an Expo-compatible alias. Typecheck and Jest run from monorepo CI until jumbo adds matching package scripts."
+      "notes": "dev is the Expo bundler. start is an Expo-compatible alias. Monorepo CI runs lint, knip, tsc, and Jest. Prettier and pnpm audit are still dirty on the current pin (Expo image-size advisory)."
     },
     {
       "id": "cli",

--- a/tooling/tasks.json
+++ b/tooling/tasks.json
@@ -285,6 +285,7 @@
       "capabilities": [
         "install",
         "dev",
+        "start",
         "lint",
         "format",
         "knip",
@@ -292,7 +293,7 @@
       ],
       "owner": "mobile",
       "risk": "medium",
-      "notes": "dev is the Expo bundler. start remains an Expo-compatible alias."
+      "notes": "dev is the Expo bundler. start is an Expo-compatible alias. Typecheck and Jest run from monorepo CI until jumbo adds matching package scripts."
     },
     {
       "id": "cli",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Jumbo is already a required private submodule (`apps/jumbo` → `lomiafrica/jumbo`) with Metro/Babel/TS pointed at `@lomi./shared` and `@lomi./queries`. This PR finishes the monorepo-side wiring so it is treated like the other private apps.

## What

- Add `.github/workflows/app-ci-jumbo.yml`: checkout the pin, install via `tooling/scripts/install-app-with-packages.mjs`, then lint, knip, `tsc --noEmit`, and Jest.
- Record `start` on the Jumbo task-registry entry (script already exists; Expo alias of `dev`).
- Pin the submodule tracking branch to `main`.
- List lomi. Pos in the root README and the EN/FR open-source docs.

## Why

After the package extract, Jumbo consumed shared packages locally but had no monorepo CI and no public-tree mention. Agents and contributors could not tell it was a first-class app, and package/Metro regressions would not fail the umbrella repo.

## How

CI follows the Shopify/plugin pattern: `init-submodules.sh` + `install-app-with-packages.mjs`. Typecheck and Jest are invoked with `pnpm exec` because Jumbo’s `package.json` does not yet declare `typecheck` / `test` scripts.

Prettier and `pnpm audit` are intentionally not in this workflow. At pin `a64ba4e`, `pnpm format` fails on 62 files, and `pnpm audit --audit-level high` reports Expo Metro `image-size` advisories. Those belong in a Jumbo-repo follow-up, not a red umbrella job.

## Testing

Verified locally after `node tooling/scripts/install-app-with-packages.mjs apps/jumbo`:

- `pnpm lint` — pass (15 warnings, 0 errors)
- `pnpm knip` — pass
- `pnpm exec tsc --noEmit --incremental false` — pass
- `pnpm exec jest --ci --watchman=false` — 14 suites, 42 tests, all pass
- Task registry lists Jumbo as `present`
- Submodule pin unchanged (`a64ba4e`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0788b-b16f-785a-a67b-2622ab8ec372?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0788b-b16f-785a-a67b-2622ab8ec372&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

