### PR TITLE
Restore path for accidental merchant account deletes

### DIFF
--- a/packages/queries/src/admin/misc.ts
+++ b/packages/queries/src/admin/misc.ts
@@ -82,6 +82,17 @@ export async function rejectManualRefundRequest(
   return callRpc(client, "reject_manual_refund_request", args, "reject_manual_refund_request", options);
 }
 
+export async function restoreMerchant(
+  client: TypedSupabaseClient,
+  args: DbFunctions["restore_merchant"]["Args"],
+  options?: SupabaseRpcOptions<DbFunctions["restore_merchant"]["Returns"]> | null,
+): Promise<DbFunctions["restore_merchant"]["Returns"] | null | boolean> {
+  if (options === null) {
+    return callRpc(client, "restore_merchant", args, "restore_merchant", { fallbackValue: null });
+  }
+  return callRpc(client, "restore_merchant", args, "restore_merchant", options);
+}
+
 export async function updateAdminDashboardAccessConfig(
   client: TypedSupabaseClient,
   args: DbFunctions["update_admin_dashboard_access_config"]["Args"],

--- a/packages/shared/src/database.ts
+++ b/packages/shared/src/database.ts
@@ -26098,6 +26098,10 @@ export type Database = {
         Args: { p_organization_id: string; p_raw_order: Json }
         Returns: Json
       }
+      restore_merchant: {
+        Args: { p_merchant_id: string }
+        Returns: Json
+      }
       retry_webhook_delivery: {
         Args: { p_log_id: string; p_merchant_id: string; p_webhook_id: string }
         Returns: boolean


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Incident

Daniel Whannou / Rythmiqo (`62213bb1-906d-4cec-81e4-5fdf0ea36279`, `dwhannou229@gmail.com`) used dashboard Settings danger zone **Delete account** while trying to remove a secondary org (SKOLARADAR). That calls `soft_delete_merchant`, not `soft_delete_organization`.

**Restored in prod:** yes. Rythmiqo membership is active again. SKOLARADAR stays soft-deleted (the intended org removal). KYC / `verification_status` was not changed (`starter`).

Daniel can sign in at https://dashboard.lomi.africa with Google (`dwhannou229@gmail.com`). Onboarding is already completed. Do not email him.

## What delete does

- **Delete organization:** `soft_delete_organization`. Refuses the last live org. Soft-deletes the org if the merchant was the last active member.
- **Delete account:** `soft_delete_merchant`. Sets `merchants.is_deleted`, bans auth (`banned_until = infinity`), inactivates every org link, and soft-deletes only the *current* org if they were its last active member. Both dialogs ask the merchant to type the current org name, which is how this mix-up happens.
- **Hard delete:** `delete_merchant_cascade` is not recoverable.

Existing `unban_user` is too blunt: it reactivates every membership, including orgs that should stay deleted.

## Ops path going forward

In the prod SQL editor (or as platform admin / service_role):

```sql
SELECT public.restore_merchant('<merchant_uuid>');
```

This unbans auth, clears deletion flags, and reactivates links only to non-deleted orgs. It does not undelete organizations and does not change KYC.

Dashboard commit: `lomiafrica/dashboard` branch `cursor/restore-merchant-5b9a` (RPC + AGENTS.md note). Function is already applied on prod.

## Daniel next step

Sign in with Google on the dashboard. He should land on Rythmiqo. No re-verify. If Google sign-in fails, check `auth.users.banned_until` is null.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e332e993-13c3-44a4-ba40-697d5ea65b9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e332e993-13c3-44a4-ba40-697d5ea65b9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

