### PR TITLE
Wire Jumbo (lomi. Pos) into monorepo CI

### DIFF
--- a/.github/workflows/app-ci-jumbo.yml
+++ b/.github/workflows/app-ci-jumbo.yml
@@ -1,0 +1,67 @@
+name: lomi · ci · jumbo
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "apps/jumbo/**"
+      - "packages/shared/**"
+      - "packages/queries/**"
+      - "tooling/scripts/install-app-with-packages.mjs"
+      - ".github/workflows/app-ci-jumbo.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/jumbo/**"
+      - "packages/shared/**"
+      - "packages/queries/**"
+      - "tooling/scripts/install-app-with-packages.mjs"
+      - ".github/workflows/app-ci-jumbo.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/jumbo
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Checkout jumbo submodule
+        working-directory: .
+        env:
+          TOKEN: ${{ secrets.REPO_CHECKOUT_PAT }}
+        run: bash .github/scripts/init-submodules.sh apps/jumbo
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: |
+            apps/jumbo/pnpm-lock.yaml
+            packages/shared/package.json
+            packages/queries/package.json
+
+      - name: Install Jumbo + shared packages
+        working-directory: .
+        run: node tooling/scripts/install-app-with-packages.mjs apps/jumbo
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Knip
+        run: pnpm knip
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ We are progressively open-sourcing the monorepo toward **eventual self-hosting**
 - **Proprietary**:
   - API service: **[apps/api](./apps/api)** (`lomiafrica/api`)
   - Admin dashboard: **[apps/admin](./apps/admin)**
+  - Merchant phone app (lomi. Pos): **[apps/jumbo](./apps/jumbo)** (`lomiafrica/jumbo`)
 
 All open-source repositories will be merged into the monorepo in the coming months.
 

--- a/tooling/tasks.json
+++ b/tooling/tasks.json
@@ -285,14 +285,17 @@
       "capabilities": [
         "install",
         "dev",
+        "start",
         "lint",
         "format",
         "knip",
+        "typecheck",
+        "test",
         "types:generate"
       ],
       "owner": "mobile",
       "risk": "medium",
-      "notes": "dev is the Expo bundler. start remains an Expo-compatible alias."
+      "notes": "dev is the Expo bundler. start is an Expo-compatible alias. Monorepo CI runs lint, knip, tsc, and Jest."
     },
     {
       "id": "cli",


### PR DESCRIPTION
## Summary
- Add `lomi · ci · jumbo` (lint, knip, `tsc`, Jest) using the shared installer, without `.gitmodules` or docs MDX edits that trip unrelated red jobs.
- Record Jumbo `start` / `typecheck` / `test` in the task registry and list lomi. Pos under proprietary apps.
- Pin Jumbo to `efd3144` so typecheck passes on the current tree.

Supersedes #87 and #90. Jumbo CI on those branches was the right idea; they were behind `main` or carried extra path-filter landmines.

## Test plan
- [ ] `lomi · ci · jumbo` check is green
- [ ] No submodule pins other than Jumbo moved
- [ ] Docs / agent-plugin / parity jobs are not started by this diff


Made with [Cursor](https://cursor.com)