### PR TITLE
Fix public-id prefix collisions and land shared tests

### DIFF
--- a/.github/workflows/app-ci-monorepo.yml
+++ b/.github/workflows/app-ci-monorepo.yml
@@ -15,6 +15,7 @@ jobs:
       cli: ${{ steps.changes.outputs.cli }}
       admin: ${{ steps.changes.outputs.admin }}
       checkout: ${{ steps.changes.outputs.checkout }}
+      shared: ${{ steps.changes.outputs.shared }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -39,6 +40,8 @@ jobs:
               - 'apps/checkout'
               - 'packages/shared/**'
               - 'packages/queries/**'
+            shared:
+              - 'packages/shared/**'
 
   build-api:
     needs: detect-changes
@@ -167,4 +170,22 @@ jobs:
       - name: Install checkout dependencies
         working-directory: .
         run: node tooling/scripts/install-app-with-packages.mjs apps/checkout
+      - run: pnpm test
+
+  test-shared:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.shared == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/shared
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: pnpm install --ignore-workspace --no-frozen-lockfile
       - run: pnpm test

--- a/packages/pay/pnpm-lock.yaml
+++ b/packages/pay/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:

--- a/packages/queries/src/admin/misc.ts
+++ b/packages/queries/src/admin/misc.ts
@@ -71,6 +71,17 @@ export async function manualAdjustChannelBalance(
   return callRpc(client, "manual_adjust_channel_balance", args, "manual_adjust_channel_balance", options);
 }
 
+export async function restoreMerchant(
+  client: TypedSupabaseClient,
+  args: DbFunctions["restore_merchant"]["Args"],
+  options?: SupabaseRpcOptions<DbFunctions["restore_merchant"]["Returns"]> | null,
+): Promise<DbFunctions["restore_merchant"]["Returns"] | null | boolean> {
+  if (options === null) {
+    return callRpc(client, "restore_merchant", args, "restore_merchant", { fallbackValue: null });
+  }
+  return callRpc(client, "restore_merchant", args, "restore_merchant", options);
+}
+
 export async function rejectManualRefundRequest(
   client: TypedSupabaseClient,
   args: DbFunctions["reject_manual_refund_request"]["Args"],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -70,6 +70,7 @@
     "watch": "tsc -p tsconfig.build.json --watch",
     "prepare": "pnpm run build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --import tsx --test src/*.test.ts",
     "types:generate": "node scripts/generate-database-types.mjs",
     "types": "pnpm run types:generate",
     "types:compare": "node scripts/compare-database-types.mjs",
@@ -79,6 +80,7 @@
     "libphonenumber-js": "^1.12.6"
   },
   "devDependencies": {
+    "tsx": "^4.23.13",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/shared/pnpm-lock.yaml
+++ b/packages/shared/pnpm-lock.yaml
@@ -12,14 +12,188 @@ importers:
         specifier: ^1.12.6
         version: 1.13.12
     devDependencies:
+      tsx:
+        specifier: ^4.23.13
+        version: 4.23.13
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
 
 packages:
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   libphonenumber-js@1.13.12:
     resolution: {integrity: sha512-uLVeV1c9OTk6qkdqnj+mpMD+ZdnZ0szVyWu58HwMmpwkHA1gCEkyjd3veZQXDnuw9KEwSRjcc9B1pS9XKIN1fA==}
+
+  tsx@4.23.13:
+    resolution: {integrity: sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -28,6 +202,122 @@ packages:
 
 snapshots:
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  fsevents@2.3.3:
+    optional: true
+
   libphonenumber-js@1.13.12: {}
+
+  tsx@4.23.13:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   typescript@5.9.3: {}

--- a/packages/shared/src/money.test.ts
+++ b/packages/shared/src/money.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  MONEY_MAX_MINOR,
+  assertAmountMinor,
+  currencyExponent,
+  fromLedgerMajor,
+  isAmountMinor,
+  majorToMinorUnits,
+  minorToMajorUnits,
+  toLedgerMajor,
+} from "./money.js";
+import { parseCheckoutCurrencyCode } from "./currency-code.js";
+
+test("currency exponents treat XOF as zero-decimal and cards as cents", () => {
+  assert.equal(currencyExponent("XOF"), 0);
+  assert.equal(currencyExponent("USD"), 2);
+  assert.equal(currencyExponent("EUR"), 2);
+  assert.equal(currencyExponent("GBP"), 0);
+  assert.equal(parseCheckoutCurrencyCode("USD"), "USD");
+  assert.equal(parseCheckoutCurrencyCode("bogus"), "XOF");
+});
+
+test("assertAmountMinor accepts chargeable integers and rejects unsafe values", () => {
+  assert.deepEqual(assertAmountMinor(10000, "XOF"), {
+    ok: true,
+    amountMinor: 10000,
+  });
+  assert.equal(assertAmountMinor(10.5, "XOF").ok, false);
+  assert.equal(assertAmountMinor(0, "XOF").ok, false);
+  assert.equal(assertAmountMinor(0, "XOF", { allowZero: true }).ok, true);
+  assert.equal(assertAmountMinor(MONEY_MAX_MINOR + 1, "XOF").ok, false);
+  assert.equal(isAmountMinor(100), true);
+  assert.equal(isAmountMinor(1.25), false);
+});
+
+test("ledger conversion is identity for XOF and cents for USD", () => {
+  assert.equal(toLedgerMajor(10000, "XOF"), 10000);
+  assert.equal(fromLedgerMajor(10000, "XOF"), 10000);
+  assert.equal(minorToMajorUnits(10000, "USD"), 100);
+  assert.equal(majorToMinorUnits(100, "USD"), 10000);
+  assert.equal(toLedgerMajor(2500, "USD"), 25);
+});

--- a/packages/shared/src/processing-fee.test.ts
+++ b/packages/shared/src/processing-fee.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  calculateProcessingFeeSurcharge,
+  findProcessingFeeRate,
+  getCheckoutHeadlineAmount,
+  mapCheckoutMethodToFeeKey,
+  type ProcessingFeeRate,
+} from "./processing-fee.js";
+
+const WAVE_RATE: ProcessingFeeRate = {
+  provider_code: "WAVE",
+  payment_method_code: "MOBILE_MONEY",
+  percentage: 2.9,
+  fixed_amount: 200,
+  micro_threshold: 1000,
+};
+
+test("mapCheckoutMethodToFeeKey normalizes hosted method ids", () => {
+  assert.deepEqual(mapCheckoutMethodToFeeKey("wave"), {
+    provider: "WAVE",
+    paymentMethod: "MOBILE_MONEY",
+  });
+  assert.deepEqual(mapCheckoutMethodToFeeKey("STRIPE"), {
+    provider: "STRIPE",
+    paymentMethod: "CARDS",
+  });
+  assert.deepEqual(mapCheckoutMethodToFeeKey("cards"), {
+    provider: "STRIPE",
+    paymentMethod: "CARDS",
+  });
+  assert.deepEqual(mapCheckoutMethodToFeeKey("spi"), {
+    provider: "SPI",
+    paymentMethod: "BANK_TRANSFER",
+  });
+  assert.equal(mapCheckoutMethodToFeeKey("bitcoin"), null);
+  assert.equal(mapCheckoutMethodToFeeKey(null), null);
+});
+
+test("findProcessingFeeRate matches provider and rail", () => {
+  assert.deepEqual(findProcessingFeeRate([WAVE_RATE], "wave"), WAVE_RATE);
+  assert.equal(findProcessingFeeRate([WAVE_RATE], "cards"), null);
+  assert.equal(findProcessingFeeRate(undefined, "wave"), null);
+});
+
+test("calculateProcessingFeeSurcharge grosses up so the merchant nets the base", () => {
+  assert.equal(calculateProcessingFeeSurcharge(10000, WAVE_RATE, "XOF"), 505);
+  assert.equal(
+    calculateProcessingFeeSurcharge(100, WAVE_RATE, "XOF"),
+    3,
+  );
+  assert.equal(
+    Number(
+      calculateProcessingFeeSurcharge(
+        100,
+        { ...WAVE_RATE, percentage: 2, fixed_amount: 0.4, micro_threshold: 1 },
+        "USD",
+      ).toFixed(2),
+    ),
+    2.45,
+  );
+  assert.equal(
+    calculateProcessingFeeSurcharge(10000, { ...WAVE_RATE, percentage: 100 }, "XOF"),
+    0,
+  );
+  assert.equal(calculateProcessingFeeSurcharge(0, WAVE_RATE, "XOF"), 0);
+});
+
+test("getCheckoutHeadlineAmount switches to total once a surcharge exists", () => {
+  assert.equal(
+    getCheckoutHeadlineAmount({ total: 10505, processingFee: 505 }, 10000),
+    10505,
+  );
+  assert.equal(
+    getCheckoutHeadlineAmount({ total: 10000, processingFee: 0 }, 10000),
+    10000,
+  );
+});

--- a/packages/shared/src/public-id.test.ts
+++ b/packages/shared/src/public-id.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  DEFAULT_PAY_ORIGIN,
+  PUBLIC_ID_PREFIXES,
+  buildPaymentLinkCheckoutUrl,
+  formatPublicId,
+  hostedPaymentLinkUrl,
+  isCanonicalPaymentLinkPath,
+  isCheckoutLinkIdentifier,
+  isLegacyPaymentLinkPath,
+  isPaymentLinkPathSegment,
+  isPublicId,
+  isPublicIdPrefix,
+  isUuid,
+  normalizePublicId,
+  paymentLinkPathSegment,
+  publicIdPrefix,
+  publicIdsMatch,
+} from "./public-id.js";
+
+const BODY = "23456789ABCDEF";
+const ORG_ID = `${PUBLIC_ID_PREFIXES.organization}${BODY}`;
+const TXN_ID = `${PUBLIC_ID_PREFIXES.transaction}${BODY}`;
+const PLINK_ID = `${PUBLIC_ID_PREFIXES.paymentLink}${BODY}`;
+const UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+test("normalizePublicId strips separators and uppercases", () => {
+  assert.equal(normalizePublicId(" org_2345-6789 abcdef "), "ORG_23456789ABCDEF");
+});
+
+test("isUuid accepts RFC-4122 ids and rejects public ids", () => {
+  assert.equal(isUuid(UUID), true);
+  assert.equal(isUuid(` ${UUID.toUpperCase()} `), true);
+  assert.equal(isUuid(ORG_ID), false);
+  assert.equal(isUuid("not-a-uuid"), false);
+});
+
+test("isPublicId validates prefix, body length, and alphabet", () => {
+  assert.equal(isPublicIdPrefix(PUBLIC_ID_PREFIXES.organization), true);
+  assert.equal(isPublicIdPrefix("foo_"), false);
+  assert.equal(isPublicId(ORG_ID), true);
+  assert.equal(isPublicId(` ${ORG_ID.toLowerCase()} `), true);
+  assert.equal(isPublicId(ORG_ID, PUBLIC_ID_PREFIXES.organization), true);
+  assert.equal(isPublicId(ORG_ID, PUBLIC_ID_PREFIXES.customer), false);
+  assert.equal(isPublicId(`${PUBLIC_ID_PREFIXES.organization}23456789ABCDE0`), false);
+  assert.equal(isPublicId(`${PUBLIC_ID_PREFIXES.organization}${BODY}X`), false);
+  assert.equal(isPublicId(BODY), false);
+});
+
+test("formatPublicId keeps canonical prefixes except TXN_", () => {
+  assert.equal(formatPublicId(null), null);
+  assert.equal(formatPublicId("   "), null);
+  assert.equal(formatPublicId(UUID), UUID);
+  assert.equal(formatPublicId(` ${ORG_ID.toLowerCase()} `), ORG_ID);
+  assert.equal(formatPublicId(`Txn_${BODY.toLowerCase()}`), `TXN_${BODY}`);
+  assert.equal(formatPublicId(TXN_ID), `TXN_${BODY}`);
+  assert.equal(formatPublicId("orphan-id"), "ORPHANID");
+});
+
+test("publicIdsMatch compares UUIDs and public ids independently of case", () => {
+  assert.equal(publicIdsMatch(UUID, UUID.toUpperCase()), true);
+  assert.equal(publicIdsMatch(ORG_ID, ORG_ID.toLowerCase()), true);
+  assert.equal(publicIdsMatch(ORG_ID, TXN_ID), false);
+  assert.equal(publicIdsMatch(ORG_ID, null), false);
+});
+
+test("payment-link path helpers strip plink_ and reject reserved segments", () => {
+  assert.equal(paymentLinkPathSegment(PLINK_ID), BODY);
+  assert.equal(paymentLinkPathSegment(UUID), UUID);
+  assert.equal(paymentLinkPathSegment("  "), "");
+  assert.equal(isPaymentLinkPathSegment(BODY), true);
+  assert.equal(isPaymentLinkPathSegment(PLINK_ID), true);
+  assert.equal(isPaymentLinkPathSegment("instant"), false);
+  assert.equal(isPaymentLinkPathSegment("checkout"), false);
+  assert.equal(isPaymentLinkPathSegment("api"), false);
+  assert.equal(isCheckoutLinkIdentifier(BODY), true);
+  assert.equal(isCheckoutLinkIdentifier(UUID), true);
+  assert.equal(isCheckoutLinkIdentifier("receipt"), false);
+});
+
+test("hostedPaymentLinkUrl keeps custom domains and rebuilds legacy paths", () => {
+  assert.equal(publicIdPrefix(PLINK_ID), PUBLIC_ID_PREFIXES.paymentLink);
+  assert.equal(isLegacyPaymentLinkPath("/instant/old"), true);
+  assert.equal(isLegacyPaymentLinkPath("/product/old"), true);
+  assert.equal(isLegacyPaymentLinkPath(`/${BODY}`), false);
+  assert.equal(isCanonicalPaymentLinkPath(`/${BODY}`), true);
+  assert.equal(isCanonicalPaymentLinkPath(`/${BODY}/extra`), false);
+  assert.equal(isCanonicalPaymentLinkPath("/instant/old"), false);
+
+  assert.equal(
+    buildPaymentLinkCheckoutUrl(PLINK_ID, "https://pay.example.com/"),
+    `https://pay.example.com/${BODY}`,
+  );
+  assert.equal(
+    hostedPaymentLinkUrl(PLINK_ID, `https://shop.example.com/${BODY}`),
+    `https://shop.example.com/${BODY}`,
+  );
+  assert.equal(
+    hostedPaymentLinkUrl(PLINK_ID, `https://shop.example.com/instant/${PLINK_ID}`),
+    `https://shop.example.com/${BODY}`,
+  );
+  assert.equal(hostedPaymentLinkUrl(PLINK_ID, "not a url"), `${DEFAULT_PAY_ORIGIN}/${BODY}`);
+  assert.equal(hostedPaymentLinkUrl(PLINK_ID), `${DEFAULT_PAY_ORIGIN}/${BODY}`);
+});
+
+const REQ_ID = `${PUBLIC_ID_PREFIXES.paymentRequest}${BODY}`;
+const REFUND_ID = `${PUBLIC_ID_PREFIXES.refund}${BODY}`;
+const PROD_ID = `${PUBLIC_ID_PREFIXES.product}${BODY}`;
+const PAYOUT_ID = `${PUBLIC_ID_PREFIXES.payout}${BODY}`;
+
+test("payment-request ids are not classified as refunds (re_ vs req_)", () => {
+  assert.equal(publicIdPrefix(REQ_ID), PUBLIC_ID_PREFIXES.paymentRequest);
+  assert.equal(publicIdPrefix(REQ_ID.toUpperCase()), PUBLIC_ID_PREFIXES.paymentRequest);
+  assert.equal(isPublicId(REQ_ID), true);
+  assert.equal(isPublicId(REQ_ID, PUBLIC_ID_PREFIXES.paymentRequest), true);
+  assert.equal(isPublicId(REQ_ID, PUBLIC_ID_PREFIXES.refund), false);
+  assert.equal(formatPublicId(REQ_ID), REQ_ID);
+  assert.equal(formatPublicId(`Req_${BODY.toLowerCase()}`), REQ_ID);
+  assert.equal(publicIdsMatch(REQ_ID, formatPublicId(REQ_ID)), true);
+});
+
+test("refund ids still resolve to re_ and do not steal req_", () => {
+  assert.equal(publicIdPrefix(REFUND_ID), PUBLIC_ID_PREFIXES.refund);
+  assert.equal(isPublicId(REFUND_ID), true);
+  assert.equal(isPublicId(REFUND_ID, PUBLIC_ID_PREFIXES.refund), true);
+  assert.equal(isPublicId(REFUND_ID, PUBLIC_ID_PREFIXES.paymentRequest), false);
+  assert.equal(formatPublicId(REFUND_ID), REFUND_ID);
+});
+
+test("product and payout prefixes do not collide (po_ vs prod_)", () => {
+  assert.equal(publicIdPrefix(PROD_ID), PUBLIC_ID_PREFIXES.product);
+  assert.equal(publicIdPrefix(PAYOUT_ID), PUBLIC_ID_PREFIXES.payout);
+  assert.equal(isPublicId(PROD_ID, PUBLIC_ID_PREFIXES.product), true);
+  assert.equal(isPublicId(PROD_ID, PUBLIC_ID_PREFIXES.payout), false);
+  assert.equal(isPublicId(PAYOUT_ID, PUBLIC_ID_PREFIXES.payout), true);
+  assert.equal(formatPublicId(PROD_ID), PROD_ID);
+  assert.equal(formatPublicId(PAYOUT_ID), PAYOUT_ID);
+});

--- a/packages/shared/src/public-id.ts
+++ b/packages/shared/src/public-id.ts
@@ -32,6 +32,21 @@ const UUID_PATTERN =
 
 const PREFIX_VALUES = new Set<string>(Object.values(PUBLIC_ID_PREFIXES));
 
+/**
+ * Longest prefix wins. `re_` (refund) is a prefix of `req_` (payment
+ * request); first-match on insertion order misclassifies `req_*` as a refund.
+ */
+function matchPublicIdPrefix(normalized: string): string | null {
+  let matched: string | null = null;
+  for (const prefix of PREFIX_VALUES) {
+    if (!normalized.startsWith(prefix.toUpperCase())) continue;
+    if (!matched || prefix.length > matched.length) {
+      matched = prefix;
+    }
+  }
+  return matched;
+}
+
 export function normalizePublicId(raw: string): string {
   return raw.trim().replace(/[\s-]/g, "").toUpperCase();
 }
@@ -46,17 +61,13 @@ export function isPublicIdPrefix(prefix: string): boolean {
 
 export function isPublicId(value: string, prefix?: string): boolean {
   const normalized = normalizePublicId(value);
-  const expectedPrefix = prefix ? prefix.toUpperCase() : null;
-  if (expectedPrefix && !normalized.startsWith(expectedPrefix)) {
+  const matchedPrefix = matchPublicIdPrefix(normalized);
+  if (!matchedPrefix) return false;
+  if (prefix && matchedPrefix.toUpperCase() !== prefix.toUpperCase()) {
     return false;
   }
 
-  const matchedPrefix = [...PREFIX_VALUES].find((item) =>
-    normalized.startsWith(item.toUpperCase()),
-  );
-  if (!matchedPrefix) return false;
-
-  const body = normalized.slice(matchedPrefix.length);
+  const body = normalized.slice(matchedPrefix.toUpperCase().length);
   if (body.length !== PUBLIC_ID_BODY_LENGTH) return false;
   for (const ch of body) {
     if (!PUBLIC_ID_ALPHABET.includes(ch)) return false;
@@ -65,11 +76,7 @@ export function isPublicId(value: string, prefix?: string): boolean {
 }
 
 export function publicIdPrefix(value: string): string | null {
-  const normalized = normalizePublicId(value);
-  const matched = [...PREFIX_VALUES].find((item) =>
-    normalized.startsWith(item.toUpperCase()),
-  );
-  return matched ?? null;
+  return matchPublicIdPrefix(normalizePublicId(value));
 }
 
 export function formatPublicId(value: string | null | undefined): string | null {

--- a/packages/shared/src/validate-checkout-customer.test.ts
+++ b/packages/shared/src/validate-checkout-customer.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type {
+  MergedCustomerData,
+  ResolvedCheckoutFormFlags,
+} from "./validate-checkout-customer.js";
+import {
+  isPhoneRequiredForPayment,
+  mergeCustomerSources,
+  validateCheckoutContactFields,
+  validateCheckoutCustomer,
+} from "./validate-checkout-customer.js";
+
+const VALID_CI_MOBILE = "+2250708091011";
+
+function form(
+  overrides: Partial<ResolvedCheckoutFormFlags> = {},
+): ResolvedCheckoutFormFlags {
+  return {
+    requireBillingAddress: false,
+    requireEmail: true,
+    requirePhone: false,
+    requireName: true,
+    showEmail: true,
+    showPhone: true,
+    showName: true,
+    customFields: [],
+    ...overrides,
+  };
+}
+
+function customer(
+  overrides: Partial<MergedCustomerData> = {},
+): MergedCustomerData {
+  return {
+    email: "ada@example.com",
+    name: "Ada Lovelace",
+    firstName: "Ada",
+    lastName: "Lovelace",
+    phoneNumber: "",
+    whatsappNumber: "",
+    country: "CI",
+    city: "",
+    address: "",
+    postalCode: "",
+    ...overrides,
+  };
+}
+
+test("isPhoneRequiredForPayment forces Wave/MTN when the phone field is shown", () => {
+  assert.equal(isPhoneRequiredForPayment(form(), "wave"), true);
+  assert.equal(isPhoneRequiredForPayment(form(), "MTN"), true);
+  assert.equal(isPhoneRequiredForPayment(form(), "cards"), false);
+  assert.equal(
+    isPhoneRequiredForPayment(form({ showPhone: false }), "wave"),
+    false,
+  );
+  assert.equal(
+    isPhoneRequiredForPayment(form({ requirePhone: true }), "cards"),
+    true,
+  );
+});
+
+test("validateCheckoutCustomer reports the first missing required field", () => {
+  assert.deepEqual(
+    validateCheckoutCustomer({
+      merged: customer({ name: "  " }),
+      resolvedForm: form(),
+      customFieldValues: {},
+    }),
+    {
+      valid: false,
+      errorCode: "missing_customer_data",
+      errorMessage: "Missing customer information",
+      field: "name",
+    },
+  );
+
+  assert.equal(
+    validateCheckoutCustomer({
+      merged: customer({ email: "not-an-email" }),
+      resolvedForm: form(),
+      customFieldValues: {},
+    }).field,
+    "email",
+  );
+
+  assert.equal(
+    validateCheckoutCustomer({
+      merged: customer(),
+      resolvedForm: form(),
+      customFieldValues: {},
+      forceRequirePhone: true,
+    }).field,
+    "phone",
+  );
+});
+
+test("validateCheckoutCustomer rejects invalid phones and incomplete billing", () => {
+  assert.deepEqual(
+    validateCheckoutCustomer({
+      merged: customer({ phoneNumber: "123" }),
+      resolvedForm: form(),
+      customFieldValues: {},
+    }),
+    {
+      valid: false,
+      errorCode: "phone_validation_error",
+      errorMessage:
+        "Please enter a valid phone number for the selected country.",
+      field: "phone",
+    },
+  );
+
+  assert.equal(
+    validateCheckoutCustomer({
+      merged: customer({ country: "CI", city: "", address: "" }),
+      resolvedForm: form({ requireBillingAddress: true }),
+      customFieldValues: {},
+    }).errorCode,
+    "missing_billing_address",
+  );
+});
+
+test("required custom fields distinguish checkboxes from text", () => {
+  const resolvedForm = form({
+    customFields: [
+      { id: "terms", type: "terms", label: "Terms", required: true },
+      { id: "note", type: "text", label: "Note", required: true },
+    ],
+  });
+
+  const missingTerms = validateCheckoutCustomer({
+    merged: customer(),
+    resolvedForm,
+    customFieldValues: { terms: "false", note: "hello" },
+  });
+  assert.equal(missingTerms.customFieldId, "terms");
+
+  const missingNote = validateCheckoutCustomer({
+    merged: customer(),
+    resolvedForm,
+    customFieldValues: { terms: "true", note: "  " },
+  });
+  assert.equal(missingNote.customFieldId, "note");
+
+  assert.equal(
+    validateCheckoutCustomer({
+      merged: customer(),
+      resolvedForm,
+      customFieldValues: { terms: "true", note: "hello" },
+    }).valid,
+    true,
+  );
+});
+
+test("validateCheckoutContactFields requires a phone for mobile money", () => {
+  const result = validateCheckoutContactFields({
+    merged: customer(),
+    resolvedForm: form(),
+    customFieldValues: {},
+    paymentMethod: "wave",
+  });
+  assert.equal(result.field, "phone");
+
+  assert.equal(
+    validateCheckoutContactFields({
+      merged: customer({ phoneNumber: VALID_CI_MOBILE }),
+      resolvedForm: form(),
+      customFieldValues: {},
+      paymentMethod: "wave",
+    }).valid,
+    true,
+  );
+});
+
+test("mergeCustomerSources prefers Stripe billing details over the form", () => {
+  const merged = mergeCustomerSources(
+    {
+      billingDetails: {
+        name: "Grace Hopper",
+        email: "grace@example.com",
+        phone: VALID_CI_MOBILE,
+        address: {
+          country: "CI",
+          city: "Abidjan",
+          line1: "Rue des Perles",
+          postal_code: "01 BP 1",
+        },
+      },
+    },
+    {
+      name: "Form Name",
+      email: "form@example.com",
+      phoneNumber: "+2250500000000",
+      country: "SN",
+      city: "Dakar",
+      address: "Form street",
+    },
+  );
+
+  assert.equal(merged.name, "Grace Hopper");
+  assert.equal(merged.firstName, "Grace");
+  assert.equal(merged.lastName, "Hopper");
+  assert.equal(merged.email, "grace@example.com");
+  assert.equal(merged.phoneNumber, VALID_CI_MOBILE);
+  assert.equal(merged.city, "Abidjan");
+  assert.equal(merged.address, "Rue des Perles");
+  assert.equal(merged.country, "CI");
+});

--- a/packages/shared/tsconfig.build.json
+++ b/packages/shared/tsconfig.build.json
@@ -9,5 +9,5 @@
     "declarationMap": false,
     "sourceMap": false
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -11,5 +11,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Takes the useful slices from stale drafts #86, #88, #89, #91, and #92 onto current `main` without restoring old files that would clobber newer helpers.

**Public IDs.** `matchPublicIdPrefix()` now picks the longest matching prefix, so `req_*` is not classified as `re_*` and `prod_*` is not `po_*`. Newer session-URL helpers on main stay.

**Tests.** `packages/shared` unit tests for public ids, money, processing fees, and checkout customer validation. `pnpm test` in the package; `test-shared` job in monorepo CI.

**Admin.** `restoreMerchant` wrapper in `@lomi./queries/admin` (types were already on main).

**CI.** `@lomi./pay` lockfile `autoInstallPeers` is `false` so checkout frozen-install matches `install-app-with-packages.mjs`.

Resend webhook from #86 is already on `lomiafrica/api` main. Jumbo CI from #91 is already on umbrella main.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a087f7-e566-7571-8f6d-2696359558c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a087f7-e566-7571-8f6d-2696359558c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

