### PR TITLE
Install UI kit and pay types so Vercel app builds resolve them

### DIFF
--- a/packages/pay/package.json
+++ b/packages/pay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lomi./pay",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",
@@ -34,13 +34,13 @@
     "@lomi./queries": "file:../queries",
     "@lomi./shared": "file:../shared",
     "@lomi./ui": "file:../ui",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.5",
     "lucide-react": "^0.562.0",
     "react-phone-number-input": "^3.4.18"
   },
   "devDependencies": {
     "@types/node": "^20.19.43",
-    "@types/react": "^19.2.18",
-    "@types/react-dom": "^19.2.5",
     "next": "^16.3.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lomi./ui",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",
@@ -136,24 +136,13 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "lottie-react": ">=2",
     "react": ">=18",
-    "react-day-picker": ">=8",
-    "react-dom": ">=18",
-    "sileo": ">=0"
-  },
-  "peerDependenciesMeta": {
-    "lottie-react": {
-      "optional": true
-    },
-    "react-day-picker": {
-      "optional": true
-    },
-    "sileo": {
-      "optional": true
-    }
+    "react-dom": ">=18"
   },
   "dependencies": {
+    "lottie-react": "^2.4.1",
+    "react-day-picker": "^8.10.1",
+    "sileo": "^0.1.5",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.14",
@@ -178,11 +167,8 @@
   "devDependencies": {
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.2.21",
-    "lottie-react": "^2.4.1",
     "react": "^18.2.0",
-    "react-day-picker": "^8.10.1",
     "react-dom": "^18.2.0",
-    "sileo": "^0.1.5",
     "typescript": "^5.9.3"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lomi./ui",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",
@@ -158,6 +158,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "date-fns": "^3.6.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.300.0",
     "motion": "^12.23.12",

--- a/tooling/scripts/install-app-with-packages.mjs
+++ b/tooling/scripts/install-app-with-packages.mjs
@@ -23,6 +23,9 @@
  * 22, and a restored `.pnpm` tree from cache makes it worse). Website/admin
  * npm deploys still use `npm install --omit=dev --omit=peer`. @lomi./pay
  * installs with the same omit flags so it does not pull a second Next.
+ * Keep `@types/react` / `@types/react-dom` in pay `dependencies` so checkout
+ * typecheck can resolve `react` next to the nested runtime copy lucide pulls.
+ * Keep `date-fns` in UI `dependencies` so Vite can resolve react-day-picker.
  *
  * Usage: node tooling/scripts/install-app-with-packages.mjs <app-dir>
  *   e.g. node tooling/scripts/install-app-with-packages.mjs apps/docs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Vercel installs `@lomi./ui` and `@lomi./pay` with `omit-dev` and `omit-peer`.

- Toast (`sileo`), calendar (`react-day-picker`), and Lottie were only peer/dev deps, so `packages/ui/node_modules` never got them. Dashboard, admin, and checkout then failed when compiling UI source.
- `react-day-picker` also needs `date-fns` as a peer. After moving the calendar into UI dependencies, dashboard Vite failed to resolve `date-fns` from the nested `packages/ui/node_modules/react-day-picker`.
- Checkout typecheck compiles `@lomi./pay` source. Lucide installs a nested `react` runtime under `packages/pay/node_modules`, and `@types/react` lived in pay `devDependencies`, so Next reported `TS7016` for `react` / `react/jsx-runtime`.

This PR:
- Moves `sileo`, `lottie-react`, `react-day-picker`, and `date-fns` to UI `dependencies` (0.1.14)
- Moves `@types/react` / `@types/react-dom` to pay `dependencies` (0.1.5)
- Leaves React and Next as peers/dev so checkout does not install a second Next

React stays a peer on both kits.

Production CLI deploys using this tree are READY:
- `dashboard.lomi.africa` (`dpl_8jqVLKPD9JmBBgLriMgLhMTWExb3`, dashboard `8e2bb39f`)
- `pay.lomi.africa` (`dpl_Fr3z9bkRUsVN1QEd9nW8JdbpVhSA`, checkout `1ac70d4` plus this package fix)
- `admin.lomi.africa` (`dpl_GrSLuKodWq4dhGcxZZHqRP42TuBM`, admin `8050d89`, UI 0.1.13 which was enough for admin)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a087f2-0b27-7e66-8864-ff4de7b6798d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a087f2-0b27-7e66-8864-ff4de7b6798d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

