### PR TITLE
Deploy dashboard when the app or API gitlink moves

### DIFF
--- a/.github/workflows/app-deploy-dashboard.yml
+++ b/.github/workflows/app-deploy-dashboard.yml
@@ -6,7 +6,10 @@ on:
   push:
     branches: [main]
     paths:
+      - "apps/dashboard"
       - "apps/dashboard/**"
+      - "apps/api"
+      - "apps/api/**"
       - "packages/**"
       - "pnpm-workspace.yaml"
       - "package.json"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub `apps/dashboard/**` path filters do not match the submodule gitlink at `apps/dashboard`, so pin-only umbrella commits never retrigger dashboard Vercel.

This also matches `apps/api`, which dashboard checks out as an extra submodule for `@edge` notification helpers.

Merging this retriggers the dashboard deploy against the pinned API SHA that uses index `process.env` access.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5704372e-caf1-4573-a865-dd51ccbb0ad7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5704372e-caf1-4573-a865-dd51ccbb0ad7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

